### PR TITLE
Fix: Resolve StreamlitDuplicateElementKey crash in badge preview

### DIFF
--- a/app.py
+++ b/app.py
@@ -233,14 +233,16 @@ with tab4:
         else:
             # Render Preview
             md_output = ""
+            # Making Global Variable, if user wants to match the theme:   
+            should_match = st.checkbox("Match Theme Color", value=False, key="match_theme_global")
             for name, conf in all_selected_badges:
                 # Logic to use custom color if user wants consistency?
                 # User asked for customization.
                 # Let's add a "Override All Colors" checkbox
                 
                 final_color = conf['color']
-                # If usage wants to match theme:
-                if st.checkbox("Match Theme Color", value=False, key="match_theme"):
+                # Using the variable we captured before:
+                if should_match:
                     final_color = current_theme_opts['title_color'].replace("#", "")
                 
                 url = badge_generator.generate_badge_url(name, final_color, conf['logo'], style=badge_style)


### PR DESCRIPTION
Hi, I encountered a `StreamlitDuplicateElementKey` error when selecting multiple badges because the 'Match Theme' checkbox was being generated inside the loop with the same key. I moved it outside the loop to act as a global variable, and resolved the crash.

**Before:** 
<img width="1314" height="640" alt="image" src="https://github.com/user-attachments/assets/2e159cb4-645c-427a-a514-f844493a5b2a" />

**After:**
<img width="1314" height="640" alt="image" src="https://github.com/user-attachments/assets/7eb08649-d8fa-468d-9fa7-efa0eb08e2e0" />

