### PR TITLE
Expanded .gitignore to include IDEs, venv, and streamlit secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,53 @@
+# Python (Compiled files)
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.flakes/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
 
+# Virtual Environments
+venv/
+env/
+.venv/
+ENV/
+bin/
+include/
+lib/
+share/
+
+# IDEs and Editors
+.vscode/
+.idea/
+*.swp
+*.swo
+.project
+.pydevproject
+.settings/
+
+# Operating System
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# Environment Variables & Secrets
 .env
+.flaskenv
+.streamlit/secrets.toml
+
+# Logs
+*.log


### PR DESCRIPTION
### Aperture 3.0 Contribution

**Description**
This PR adds a comprehensive` .gitignore` file to prevent tracking of compiled Python files, virtual environments, and IDE settings.

**Changes**
Added ignores for `__pycache__`, `venv`, `.vscode`, and .`streamlit`.
Verified locally that junk files are no longer tracked.

**Fixes #28**