### PR TITLE
Add Visual Elements tab for emojis, GIFs, and stickers

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,19 @@ from roast_widget_streamlit import render_roast_widget
 from generators import stats_card, lang_card, contrib_card, badge_generator
 from utils import github_api
 from themes.styles import THEMES
+from generators.visual_elements import (
+    emoji_element,
+    gif_element,
+    sticker_element
+)
+
+# Initialize canvas in session state
+if "canvas" not in st.session_state:
+    st.session_state["canvas"] = []
+
+for item in st.session_state["canvas"]:
+    st.markdown(item, unsafe_allow_html=True)
+
 
 # Load environment variables
 load_dotenv()
@@ -95,7 +108,7 @@ if custom_colors:
     current_theme_opts.update(custom_colors)
 
 # --- Layout: Tabs ---
-tab1, tab2, tab3, tab4, tab5 = st.tabs(["Main Stats", "Languages", "Contributions", "Icons & Badges", "🔥 AI Roast"])
+tab1, tab2, tab3, tab4, tab5, tab6 = st.tabs(["Main Stats", "Languages", "Contributions", "Icons & Badges", "🔥 AI Roast","✨ Visual Elements"])
 
 def show_code_area(code_content, label="Markdown Code"):
     st.markdown(f"**{label}** (Copy below)")
@@ -242,3 +255,27 @@ with tab5:
         render_roast_widget(username)
     else:
         st.warning("Please enter a GitHub username in the sidebar.")
+
+with tab6:
+    st.subheader("✨ Visual Elements")
+    st.markdown("Add emojis, GIFs, or stickers to your canvas")
+
+    element_type = st.selectbox(
+        "Choose element type",
+        ["Emoji", "GIF", "Sticker"]
+    )
+
+    value = st.text_input(
+        "Enter value",
+        placeholder="🔥 or https://gif-url"
+    )
+
+    if st.button("Add to Canvas"):
+        if element_type == "Emoji":
+            svg = emoji_element(value)
+        elif element_type == "GIF":
+            svg = gif_element(value)
+        else:
+            svg = sticker_element(value)
+
+        st.session_state["canvas"].append(svg)

--- a/generators/visual_elements.py
+++ b/generators/visual_elements.py
@@ -1,0 +1,36 @@
+# generators/visual_elements.py
+
+def emoji_element(emoji: str, size: int = 48) -> str:
+    """
+    Generate SVG for an emoji
+    """
+    return f"""
+    <svg xmlns="http://www.w3.org/2000/svg" width="{size}" height="{size}">
+        <text x="50%" y="50%" dominant-baseline="middle"
+              text-anchor="middle" font-size="{size}px">
+            {emoji}
+        </text>
+    </svg>
+    """
+
+
+def gif_element(gif_url: str, size: int = 120) -> str:
+    """
+    Generate SVG wrapper for a GIF
+    """
+    return f"""
+    <svg xmlns="http://www.w3.org/2000/svg" width="{size}" height="{size}">
+        <image href="{gif_url}" width="{size}" height="{size}" />
+    </svg>
+    """
+
+
+def sticker_element(image_url: str, size: int = 100) -> str:
+    """
+    Generate SVG for a sticker / icon
+    """
+    return f"""
+    <svg xmlns="http://www.w3.org/2000/svg" width="{size}" height="{size}">
+        <image href="{image_url}" width="{size}" height="{size}" />
+    </svg>
+    """


### PR DESCRIPTION
## Summary
Added a new **Visual Elements** tab to the editor UI that allows users to insert emojis, GIFs, and sticker/image elements into the canvas.

## Features
- New Visual Elements tab alongside existing tabs (Main Stats, Languages, etc.)
- Users can select an element type (Emoji / GIF / Sticker)
- Selected elements are added directly to the canvas
- Uses the same state management and rendering flow as existing components

## Result
Users can visually enhance their profiles using emojis, GIFs, and stickers without impacting existing functionality.
<img width="1916" height="953" alt="Screenshot 2026-02-03 150742" src="https://github.com/user-attachments/assets/2cf7b952-6ebb-40cf-a00a-22dfb05e1714" />
<img width="1918" height="943" alt="Screenshot 2026-02-03 150916" src="https://github.com/user-attachments/assets/7ab971d0-52d6-4489-b50f-45cfa947a6f3" />
