### PR TITLE
Updated for view recent activity

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI, Response, Query
-from generators import stats_card, lang_card, contrib_card
+from generators import stats_card, lang_card, contrib_card, recent_activity_card
 from utils import github_api
 from typing import Optional
 
@@ -70,4 +70,20 @@ async def get_contributions(
     data = github_api.get_live_github_data(username) or github_api.get_mock_data(username)
     custom_colors = parse_colors(bg_color, title_color, text_color, border_color)
     svg_content = contrib_card.draw_contrib_card(data, theme, custom_colors=custom_colors)
+    return Response(content=svg_content, media_type="image/svg+xml")
+
+
+@app.get("/api/recent")
+async def get_recent(
+    username: str,
+    theme: str = "Default",
+    token: Optional[str] = None,
+    bg_color: Optional[str] = None,
+    title_color: Optional[str] = None,
+    text_color: Optional[str] = None,
+    border_color: Optional[str] = None
+):
+    data = github_api.get_live_github_data(username) or github_api.get_mock_data(username)
+    custom_colors = parse_colors(bg_color, title_color, text_color, border_color)
+    svg_content = recent_activity_card.draw_recent_activity_card({'username': username}, theme, custom_colors=custom_colors, token=token)
     return Response(content=svg_content, media_type="image/svg+xml")

--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ import base64
 import os
 from dotenv import load_dotenv  # type: ignore
 from roast_widget_streamlit import render_roast_widget  # type: ignore
-from generators import stats_card, lang_card, contrib_card, badge_generator  # type: ignore
+from generators import stats_card, lang_card, contrib_card, badge_generator, recent_activity_card  # type: ignore
 from utils import github_api  # type: ignore
 from themes.styles import THEMES  # type: ignore
 
@@ -77,6 +77,7 @@ with st.sidebar:
 
     if st.button("Refresh Data", use_container_width=True):
         st.cache_data.clear()
+    github_token = st.text_input("GitHub Token (optional)", type="password")
         
     st.info("💡 Tip: Use the 'Badges' tab to add your tech stack icons!")
 
@@ -97,7 +98,7 @@ if custom_colors:
     current_theme_opts.update(custom_colors)
 
 # --- Layout: Tabs ---
-tab1, tab2, tab3, tab4, tab5 = st.tabs(["Main Stats", "Languages", "Contributions", "Icons & Badges", "🔥 AI Roast"])
+tab1, tab2, tab3, tab4, tab5, tab6 = st.tabs(["Main Stats", "Languages", "Contributions", "Icons & Badges", "🔥 AI Roast", "Recent Activity"])
 
 def show_code_area(code_content, label="Markdown Code"):
     st.markdown(f"**{label}** (Copy below)")
@@ -269,3 +270,35 @@ with tab5:
         render_roast_widget(username)
     else:
         st.warning("Please enter a GitHub username in the sidebar.")
+
+with tab6:
+    st.subheader("Recent Activity")
+    st.markdown("Shows your last 3 PR or Issue events from GitHub.")
+
+    col1, col2 = st.columns([1.5, 1])
+    with col1:
+        st.caption("Theme: **{}**".format(selected_theme))
+        try:
+            svg_bytes = recent_activity_card.draw_recent_activity_card({'username': username}, selected_theme, custom_colors, token=github_token)
+        except Exception as e:
+            st.error(f"Error rendering recent activity: {e}")
+            svg_bytes = recent_activity_card._render_svg_lines([f"Error: {e}"], THEMES.get(selected_theme, THEMES['Default']))
+
+        b64 = base64.b64encode(svg_bytes.encode('utf-8')).decode("utf-8")
+        st.markdown(f'<img src="data:image/svg+xml;base64,{b64}" style="max-width: 100%; box-shadow: 0 4px 6px rgba(0,0,0,0.3); border-radius: 10px;"/>', unsafe_allow_html=True)
+
+    with col2:
+        st.subheader("Integration")
+        params = []
+        if selected_theme != "Default": params.append(f"theme={selected_theme}")
+        for k, v in custom_colors.items():
+            params.append(f"{k}={v.replace('#', '')}")
+        if github_token:
+            params.append(f"token={github_token}")
+
+        query_str = "&".join(params)
+        if query_str: query_str = "?" + query_str
+
+        url = f"https://gitcanvas-api.vercel.app/api/recent{query_str}&username={username}"
+        code = f"![Recent Activity]({url})"
+        show_code_area(code)

--- a/generators/recent_activity_card.py
+++ b/generators/recent_activity_card.py
@@ -1,0 +1,109 @@
+import svgwrite
+import requests
+from themes.styles import THEMES
+
+
+def draw_recent_activity_card(data, theme_name="Default", custom_colors=None, token=None):
+    """
+    Fetches the user's GitHub events and renders a simple text-based SVG
+    showing the last 3 Pull Request or Issue events.
+
+    Params:
+      data: dict with at least 'username'
+      theme_name: theme key from THEMES
+      custom_colors: dict to override theme values
+      token: optional GitHub token string for higher rate limit
+
+    Returns: SVG string
+    """
+    username = data.get('username')
+    if not username:
+        raise ValueError("data must include 'username'")
+
+    theme = THEMES.get(theme_name, THEMES["Default"]).copy()
+    if custom_colors:
+        theme.update(custom_colors)
+
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    if token:
+        headers["Authorization"] = f"token {token}"
+
+    url = f"https://api.github.com/users/{username}/events"
+    try:
+        resp = requests.get(url, headers=headers, timeout=8)
+    except Exception as e:
+        # Return an SVG with the error
+        return _render_svg_lines([f"Error fetching events: {e}"], theme)
+
+    if resp.status_code != 200:
+        return _render_svg_lines([f"GitHub API error: {resp.status_code}"], theme)
+
+    events = resp.json()
+
+    lines = []
+    for ev in events:
+        if ev.get('type') == 'PullRequestEvent':
+            payload = ev.get('payload', {})
+            action = payload.get('action')
+            pr = payload.get('pull_request', {})
+            number = pr.get('number')
+            title = pr.get('title') or ''
+            repo = ev.get('repo', {}).get('name', '')
+            merged = pr.get('merged')
+
+            if merged:
+                lines.append(f"Merged PR #{number} in {repo}: {title}")
+            else:
+                if action == 'opened':
+                    lines.append(f"Opened PR #{number} in {repo}: {title}")
+                elif action == 'closed':
+                    lines.append(f"Closed PR #{number} in {repo}: {title}")
+                else:
+                    lines.append(f"PR #{number} {action} in {repo}: {title}")
+
+        elif ev.get('type') == 'IssuesEvent':
+            payload = ev.get('payload', {})
+            action = payload.get('action')
+            issue = payload.get('issue', {})
+            number = issue.get('number')
+            title = issue.get('title') or ''
+            repo = ev.get('repo', {}).get('name', '')
+
+            if action == 'opened':
+                lines.append(f"Opened Issue #{number} in {repo}: {title}")
+            elif action == 'closed':
+                lines.append(f"Closed Issue #{number} in {repo}: {title}")
+            else:
+                lines.append(f"Issue #{number} {action} in {repo}: {title}")
+
+        if len(lines) >= 3:
+            break
+
+    if not lines:
+        lines = ["No recent PRs or Issues found."]
+
+    return _render_svg_lines(lines[:3], theme)
+
+
+def _render_svg_lines(lines, theme):
+    width = 520
+    height = 120
+    dwg = svgwrite.Drawing(size=("100%", "100%"), viewBox=f"0 0 {width} {height}")
+
+    dwg.add(dwg.rect(insert=(0, 0), size=(width, height), rx=8, ry=8,
+                     fill=theme["bg_color"], stroke=theme["border_color"], stroke_width=2))
+
+    title = "Recent Activity"
+    dwg.add(dwg.text(title, insert=(20, 30),
+                     fill=theme["title_color"], font_size=theme.get("title_font_size", 18),
+                     font_family=theme.get("font_family", "sans-serif"), font_weight="bold"))
+
+    y = 55
+    for i, line in enumerate(lines):
+        # simple truncation to avoid overflow
+        text = line if len(line) <= 80 else line[:77] + '...'
+        dwg.add(dwg.text(text, insert=(20, y + i * 20),
+                         fill=theme["text_color"], font_size=theme.get("text_font_size", 14),
+                         font_family=theme.get("font_family", "sans-serif")))
+
+    return dwg.tostring()


### PR DESCRIPTION
# Solution: Recent Activity Card

## Summary

This document describes the fix and integration for the "Recent Activity" card which fetches a user's GitHub events, parses the last 3 Pull Request or Issue events, and renders them as a simple text-based SVG card.

## Problem

- The project lacked a dedicated generator to show a user's most recent PR/Issue activity.
- There was no Streamlit UI tab or API endpoint to render this card.
- Users can hit GitHub rate limits if unauthenticated requests are used.

## Changes Implemented

- Added generator: `generators/recent_activity_card.py`
  - Function: `draw_recent_activity_card(data, theme_name, custom_colors=None, token=None)`
  - Fetches `https://api.github.com/users/{username}/events` (uses `requests`).
  - Parses `PullRequestEvent` and `IssuesEvent` and creates short lines such as:
    - `Merged PR #42 in owner/repo: Fix bug in X`
    - `Opened Issue #17 in owner/repo: Unexpected crash`
  - Renders a compact SVG with up to 3 lines using `svgwrite`.

- Streamlit UI: `app.py`
  - Imported the generator and added a `Recent Activity` tab.
  - Added an optional `GitHub Token (optional)` password input in the sidebar which is passed to the generator to increase rate limits.
  - Integration snippet generation added for the new tab.

- API: `api/main.py`
  - Added endpoint `/api/recent` which calls the generator and returns `image/svg+xml`.

- Example (optional): An example runner that can be used to create `recent_activity.svg` (if available in `examples/`).

## Why this fixes the issue

- The generator explicitly queries the events API and filters for the relevant event types, ensuring the card shows only PRs and issues.
- The UI and API hooks make the card accessible both in the local app and programmatically.
- Optional token support mitigates GitHub rate-limits for production or frequent usage.

## How to Test Locally

1. Install dependencies (if not already):

```bash
pip install -r requirements.txt
```

2. Run the Streamlit app and open the `Recent Activity` tab:

```bash
streamlit run app.py
```

3. Or run the example (if present):

```bash
python examples/recent_activity_example.py --username octocat
```

4. Run the API server and request the card directly:

```bash
uvicorn api.main:app --reload --port 8000
curl "http://127.0.0.1:8000/api/recent?username=octocat"
```

5. If you hit rate limits (HTTP 403 / 429), create a personal access token and provide it either in the Streamlit sidebar or via the `token` query parameter.

## Files Touched

- `generators/recent_activity_card.py` — new generator
- `app.py` — Streamlit UI: new tab + token input
- `api/main.py` — new `/api/recent` eny_example.py` — CLI runner

## Next Improvements (optional)dpoint
- (optional) `examples/recent_activit

- Add unit tests mocking GitHub API responses (use `requests-mock` or `responses`).
- Improve text layout: wrap long titles across multiple lines or add tooltips in rendered HTML.
- Add caching for event requests (per-username TTL) to reduce API calls.
- Sanitize event text (strip newlines, control chars) and escape XML entities before embedding into SVG.

## Notes

- The implementation uses `requests` and `svgwrite`, both already present in `requirements.txt`.
- The solution keeps minimal visual styling consistent with existing `THEMES`.

---