### PR TITLE
Fixed theme registry overwrite so hardcoded themes are preserved

### DIFF
--- a/themes/styles.py
+++ b/themes/styles.py
@@ -65,7 +65,7 @@ THEMES = {
 import json
 import os
 
-THEMES = {}
+
 
 themes_dir = os.path.join(os.path.dirname(__file__), 'json')
 if os.path.exists(themes_dir):


### PR DESCRIPTION
This PR fixes the issue with neural theme by making sure JSON themes extend the existing registry instead of overwriting it, so hardcoded themes are preserved properly. After this change, the Neural theme is correctly registered and selectable.

So, the issue earlier was actually in the theme registry itself.
Even though the Neural theme was defined, the THEMES dict was later getting re-initialized when loading JSON-based themes, which meant all hardcoded themes (including Neural) were silently dropped at runtime.

Fixes #36 

<img width="960" height="559" alt="Screenshot 2026-02-05 230705" src="https://github.com/user-attachments/assets/5f3d72b5-b17a-43b6-b65c-7e82b900b009" />
<img width="953" height="554" alt="Screenshot 2026-02-05 230643" src="https://github.com/user-attachments/assets/9bdf0901-9710-4c92-aa98-c135b8178ecb" />
