### PR TITLE
Sort Top Languages by Usage 

### DIFF
--- a/generators/lang_card.py
+++ b/generators/lang_card.py
@@ -38,6 +38,8 @@ def draw_lang_card(data, theme_name="Default", custom_colors=None, excluded_lang
             for lang, count in langs 
             if lang.lower() not in excluded_lower
         ]
+    if langs:
+        langs = sorted(langs, key=lambda x: x[1], reverse=True)
     
     # Handle empty result after filtering
     if not langs:


### PR DESCRIPTION

This PR ensures that the **Top Languages card renders languages in descending order of usage**, independent of upstream data ordering.

## What Changed

Added explicit sorting after applying exclusions:

```python
if langs:
    langs = sorted(langs, key=lambda x: x[1], reverse=True)
