### PR TITLE
feat(theme): added fire, wednesday and squid_game themes

### DIFF
--- a/themes/fire.py
+++ b/themes/fire.py
@@ -1,0 +1,119 @@
+import svgwrite
+import random
+
+def render(data, config):
+    """
+    Fire Heatmap Theme
+    Uses UI colors from config JSON and maps activity intensity to heat colors.
+    """
+
+    contributions = data['contributions'][-365:] if len(data['contributions']) > 365 else data['contributions']
+
+    cols = 53
+    rows = 7
+    width = cols * 15 + 100
+    height = rows * 15 + 150
+
+    dwg = svgwrite.Drawing(size=("100%", "100%"), viewBox=f"0 0 {width} {height}")
+
+    # Background
+    dwg.add(dwg.rect(
+        insert=(0, 0),
+        size=("100%", "100%"),
+        fill=config["bg_color"]
+    ))
+
+    # Subtle ember particles
+    random.seed(42)
+    for _ in range(25):
+        x = random.randint(0, width)
+        y = random.randint(0, height)
+        r = random.randint(1, 2)
+        dwg.add(dwg.circle(
+            center=(x, y),
+            r=r,
+            fill=config["icon_color"],
+            opacity=0.15
+        ))
+
+    # Title
+    dwg.add(dwg.text(
+        "ACTIVITY HEATMAP",
+        insert=(width // 2, 30),
+        text_anchor="middle",
+        font_size=config["title_font_size"],
+        font_family=config["font_family"],
+        fill=config["title_color"],
+        style="letter-spacing: 2px; font-weight: bold;"
+    ))
+
+    box_size = 12
+    gap = 3
+    start_x = 50
+    start_y = 60
+
+    max_count = max([day['count'] for day in contributions]) if contributions else 1
+
+    for i, day in enumerate(contributions):
+        count = day['count']
+        col = i // 7
+        row = i % 7
+
+        x = start_x + col * (box_size + gap)
+        y = start_y + row * (box_size + gap)
+
+        # Heat color mapping
+        if count == 0:
+            fill = "#1a1a1a"
+            opacity = 0.4
+        elif count <= max_count * 0.25:
+            fill = "#5a1a00"  # ember
+            opacity = 0.6
+        elif count <= max_count * 0.5:
+            fill = "#cc3d00"  # orange flame
+            opacity = 0.8
+        elif count <= max_count * 0.75:
+            fill = "#ff2400"  # strong red
+            opacity = 0.9
+        else:
+            fill = "#ffd000"  # peak heat (yellow)
+            opacity = 1.0
+            # glow border for peak intensity
+            dwg.add(dwg.rect(
+                insert=(x - 1, y - 1),
+                size=(box_size + 2, box_size + 2),
+                fill="none",
+                stroke=config["title_color"],
+                stroke_width=1.2,
+                opacity=0.7
+            ))
+
+        dwg.add(dwg.rect(
+            insert=(x, y),
+            size=(box_size, box_size),
+            fill=fill,
+            rx=2,
+            ry=2,
+            opacity=opacity
+        ))
+
+    # Footer label
+    dwg.add(dwg.text(
+        "INTENSITY MODE",
+        insert=(10, height - 10),
+        font_size=config["text_font_size"],
+        font_family=config["font_family"],
+        fill=config["text_color"],
+        opacity=0.6
+    ))
+
+    # Border (matches schema)
+    dwg.add(dwg.rect(
+        insert=(0.5, 0.5),
+        size=(width - 1, height - 1),
+        fill="none",
+        stroke=config["border_color"],
+        stroke_width=1
+    ))
+
+    return dwg.tostring()

--- a/themes/json/fire.json
+++ b/themes/json/fire.json
@@ -1,0 +1,10 @@
+{
+    "bg_color": "#0b0b0b",
+    "border_color": "#3b1f1f",
+    "title_color": "#ff4500",
+    "text_color": "#ffae80",
+    "icon_color": "#ff6a00",
+    "font_family": "Segoe UI, Ubuntu, Sans-Serif",
+    "title_font_size": 20,
+    "text_font_size": 14
+}

--- a/themes/json/squid_game.json
+++ b/themes/json/squid_game.json
@@ -1,0 +1,10 @@
+{
+    "bg_color": "#0a0a0a",
+    "border_color": "#2a2a2a",
+    "title_color": "#ff2e88",
+    "text_color": "#f0b3c9",
+    "icon_color": "#ff6aa9",
+    "font_family": "Segoe UI, Ubuntu, Sans-Serif",
+    "title_font_size": 20,
+    "text_font_size": 14
+}

--- a/themes/json/wednesday.json
+++ b/themes/json/wednesday.json
@@ -1,0 +1,10 @@
+{
+    "bg_color": "#0b0b0f",
+    "border_color": "#2a2a33",
+    "title_color": "#8a6cff",
+    "text_color": "#c9c9d9",
+    "icon_color": "#6b6b7a",
+    "font_family": "Segoe UI, Ubuntu, Sans-Serif",
+    "title_font_size": 20,
+    "text_font_size": 14
+}

--- a/themes/squid_game.py
+++ b/themes/squid_game.py
@@ -1,0 +1,92 @@
+import svgwrite
+import random
+
+def render(data, config):
+    """
+    Squid Game Theme - Survival Contrast
+    Dark UI with neon pink intensity mapping.
+    """
+
+    contributions = data['contributions'][-365:] if len(data['contributions']) > 365 else data['contributions']
+
+    cols = 53
+    rows = 7
+    width = cols * 15 + 100
+    height = rows * 15 + 150
+
+    dwg = svgwrite.Drawing(size=("100%", "100%"), viewBox=f"0 0 {width} {height}")
+
+    # Background
+    dwg.add(dwg.rect(insert=(0, 0), size=("100%", "100%"), fill=config["bg_color"]))
+
+    # Neon particles
+    random.seed(21)
+    for _ in range(20):
+        x = random.randint(0, width)
+        y = random.randint(0, height)
+        r = random.randint(1, 2)
+        dwg.add(dwg.circle(center=(x, y), r=r, fill=config["icon_color"], opacity=0.18))
+
+    # Title
+    dwg.add(dwg.text(
+        "SURVIVAL ACTIVITY",
+        insert=(width // 2, 30),
+        text_anchor="middle",
+        font_size=config["title_font_size"],
+        font_family=config["font_family"],
+        fill=config["title_color"],
+        style="letter-spacing: 2px; font-weight: bold;"
+    ))
+
+    box_size = 12
+    gap = 3
+    start_x = 50
+    start_y = 60
+
+    max_count = max([day['count'] for day in contributions]) if contributions else 1
+
+    for i, day in enumerate(contributions):
+        count = day['count']
+        col = i // 7
+        row = i % 7
+
+        x = start_x + col * (box_size + gap)
+        y = start_y + row * (box_size + gap)
+
+        if count == 0:
+            fill = "#1a1a1a"
+        elif count <= max_count * 0.25:
+            fill = "#3b0a1a"
+        elif count <= max_count * 0.5:
+            fill = "#7a1036"
+        elif count <= max_count * 0.75:
+            fill = "#c2185b"
+        else:
+            fill = "#ff2e88"
+            dwg.add(dwg.rect(
+                insert=(x - 1, y - 1),
+                size=(box_size + 2, box_size + 2),
+                fill="none",
+                stroke=config["title_color"],
+                stroke_width=1.2,
+                opacity=0.7
+            ))
+
+        dwg.add(dwg.rect(
+            insert=(x, y),
+            size=(box_size, box_size),
+            fill=fill,
+            rx=2,
+            ry=2
+        ))
+
+    # Border
+    dwg.add(dwg.rect(
+        insert=(0.5, 0.5),
+        size=(width - 1, height - 1),
+        fill="none",
+        stroke=config["border_color"],
+        stroke_width=1
+    ))
+
+    return dwg.tostring()

--- a/themes/wednesday.py
+++ b/themes/wednesday.py
@@ -1,0 +1,78 @@
+import svgwrite
+import random
+def render(data,config):
+    """
+    Wednesday Theme - Gothic Academia
+    Dar,minimal, eerie grayscale palette with subtle violet accents.
+    """
+    
+    contributions = data['contributions'][-365:] if len(data['contributions'])>365 else data['contributions']
+    
+    cols =53
+    rows=7
+    width = cols*15+100
+    height = rows*15+150
+    
+    dwg = svgwrite.Drawing(size=("100%","100%"),viewBox=f"0 0 {width} {height}")
+    dwg.add(dwg.rect(insert=(0,0), size=("100%","100%"), fill=config["bg_color"]))
+    
+    random.seed(7)
+    for _ in range(18):
+        x = random.randint(0, width)
+        y = random.randint(0, height)
+        r = random.randint(1, 2)
+        dwg.add(dwg.circle(center=(x, y), r=r, fill=config["icon_color"], opacity=0.12))
+    dwg.add(dwg.text(
+        "GOTHIC ACTIVITY",
+        insert=(width // 2, 30),
+        text_anchor="middle",
+        font_size=config["title_font_size"],
+        font_family=config["font_family"],
+        fill=config["title_color"],
+        style="letter-spacing: 2px; font-weight: bold;"
+    ))
+
+    box_size = 12
+    gap = 3
+    start_x = 50
+    start_y = 60
+
+    max_count = max([day['count'] for day in contributions]) if contributions else 1
+
+    for i, day in enumerate(contributions):
+        count = day['count']
+        col = i // 7
+        row = i % 7
+
+        x = start_x + col * (box_size + gap)
+        y = start_y + row * (box_size + gap)
+
+        if count == 0:
+            fill = "#1a1a1a"
+        elif count <= max_count * 0.25:
+            fill = "#2c2c2c"
+        elif count <= max_count * 0.5:
+            fill = "#3a3a3a"
+        elif count <= max_count * 0.75:
+            fill = "#5a5a5a"
+        else:
+            fill = "#8a6cff"  # subtle gothic violet accent
+
+        dwg.add(dwg.rect(
+            insert=(x, y),
+            size=(box_size, box_size),
+            fill=fill,
+            rx=1,
+            ry=1
+        ))
+
+    dwg.add(dwg.rect(
+        insert=(0.5, 0.5),
+        size=(width - 1, height - 1),
+        fill="none",
+        stroke=config["border_color"],
+        stroke_width=1
+    ))
+
+    return dwg.tostring()
+    


### PR DESCRIPTION

<img width="1919" height="850" alt="Screenshot 2026-02-17 233609" src="https://github.com/user-attachments/assets/0536c954-ac9f-458b-a8e7-5c13772585ea" />
<img width="1919" height="863" alt="Screenshot 2026-02-17 233641" src="https://github.com/user-attachments/assets/9329c8de-22e4-4c58-8788-92473bf19dec" />
<img width="1919" height="865" alt="Screenshot 2026-02-17 233659" src="https://github.com/user-attachments/assets/d911e36e-0ce7-4a9b-a1f3-285278fd2b23" />


Nithya Shree A
Apertre 3.0

Issue #24 



This PR introduces three new SVG heatmap themes to expand visual customization:

Fire Theme – Maps contribution intensity to heat levels (embers → flames) using warm color scaling and glow for peak activity.

Wednesday Theme – Gothic dark-academia style with grayscale palette and subtle violet highlights for a minimal eerie aesthetic.

Squid Game Theme – High-contrast dark theme with neon pink intensity scaling to represent survival-style activity progression.

All themes:

Follow the existing render(data, config) interface

Use JSON-driven UI styling for consistency

Maintain compatibility with current theme architecture

Avoid modifying core logic or existing themes

Files added:

themes/fire.py, themes/json/fire.json

themes/wednesday.py, themes/json/wednesday.json

themes/squid_game.py, themes/json/squid_game.json

No breaking changes.