### PR TITLE
fix: improve error handling and logging in trophy generator and GitHu…

### DIFF
--- a/generators/trophy_card.py
+++ b/generators/trophy_card.py
@@ -35,7 +35,8 @@ def draw_trophy_card(data, theme_name="Default", custom_colors=None):
     else:
         repo_tier, tier_color = "Newcomer", "#CD7F32"
     
-    dwg, theme = create_svg_base(theme_name, custom_colors, width, height, f"{data['username']}'s Trophy")
+    username = data.get('username', 'Unknown')
+    dwg, theme = create_svg_base(theme_name, custom_colors, width, height, f"{username}'s Trophy")
     
     font_family = theme["font_family"]
     text_color = theme["text_color"]

--- a/utils/github_api.py
+++ b/utils/github_api.py
@@ -1,10 +1,13 @@
 import requests
 import os
+import logging
 
 try:
     from dotenv import load_dotenv
 except Exception:
     load_dotenv = None
+
+logger = logging.getLogger(__name__)
 
 GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
 
@@ -202,8 +205,9 @@ def get_live_github_data(username, token=None):
                 data["contributions"] = contributions
                 data["total_commits"] = gql_total_commits
                 data["contribution_weeks"] = contribution_weeks
-            except Exception:
-                pass  # Never break REST fallback
+            except Exception as e:
+                logger.warning(f"GraphQL failed for {username}: {e}, falling back to REST")
+                data['data_source'] = 'rest_fallback'
 
         if "contributions" not in data:
             # Fallback to empty list; UI should handle missing contribution data gracefully.


### PR DESCRIPTION
Fixed both error handling issues:

**1. `generators/trophy_card.py` (Line 38)**
- Changed `data['username']` to `data.get('username', 'Unknown')`
- This prevents a `KeyError` crash when the username field is missing from the data object

**2. `utils/github_api.py` (Lines 205-206)**
- Added `import logging` and created a logger instance at the module level
- Replaced silent `except Exception: pass` with proper error handling:
  - Logs a warning message: `logger.warning(f"GraphQL failed for {username}: {e}, falling back to REST")`
  - Tracks the data source: `data['data_source'] = 'rest_fallback'`

These changes ensure graceful error handling with proper logging and data source tracking instead of silent failures or application crashes.