### PR TITLE
fix: improve PNG/JPEG export resolution and fix aspect ratio

### DIFF
--- a/app.py
+++ b/app.py
@@ -254,17 +254,12 @@ def render_tab(svg_bytes, endpoint, username, selected_theme, custom_colors, hid
             const svgDoc = parser.parseFromString(svgText, 'image/svg+xml');
             const svgEl = svgDoc.documentElement;
 
-            let w = parseInt(svgEl.getAttribute('width')) || 0;
-            let h = parseInt(svgEl.getAttribute('height')) || 0;
-            if (!w || !h) {{
-                const vb = svgEl.getAttribute('viewBox');
-                if (vb) {{
-                    const parts = vb.split(/[\s,]+/);
-                    w = parseFloat(parts[2]) || 800;
-                    h = parseFloat(parts[3]) || 400;
-                }} else {{
-                    w = 800; h = 400;
-                }}
+            const vb = svgEl.getAttribute('viewBox');
+            let w = 800, h = 400;
+            if (vb) {{
+                const parts = vb.split(/[\s,]+/);
+                w = parseFloat(parts[2]) || 800;
+                h = parseFloat(parts[3]) || 400;
             }}
 
             const blob = new Blob([svgText], {{type: 'image/svg+xml'}});


### PR DESCRIPTION
Fixes #132

## Problem
When downloading stats cards as PNG or JPEG, the images were blurry, 
low resolution, and slightly stretched — making them unsuitable for 
sharing or embedding in README files.

## Changes Made
- Increased canvas scale to 4x for sharper, higher resolution output
- Replaced `toDataURL` with `toBlob` at quality 1.0 for better image fidelity
- Fixed `ctx.drawImage` to use `canvas.width/canvas.height` directly, 
  preventing stretched/distorted output

## Testing
- Downloaded PNG and JPEG for Stats card — sharp, correct dimensions
- Verified SVG download still works as before
- No other functionality affected

## Screenshots

## Screenshots

### Before
_Blurry, low resolution output_
![before](https://github.com/user-attachments/assets/e17b98af-4d50-4c69-9068-3ea6979cfefc)

### After
_Sharp, high resolution output_
![after](https://github.com/user-attachments/assets/8356f5f5-7820-429d-ba83-70c33e1dc184)