### PR TITLE
Security: Move GitHub token from URL to Authorization header

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -25,6 +25,29 @@ def svg_response(svg_content: str, request: Request):
     )
 
 
+def get_token_from_header(request: Request) -> Optional[str]:
+    """
+    Securely extract GitHub token from Authorization header.
+    
+    SECURITY: Tokens should NEVER be in URL parameters as they get logged in:
+    - Server access logs
+    - Browser history
+    - Proxy logs
+    - Referrer headers
+    
+    Use: Authorization: Bearer <token>
+    
+    Args:
+        request: FastAPI Request object
+        
+    Returns:
+        Token string or None if not provided
+    """
+    auth_header = request.headers.get("Authorization")
+    if auth_header and auth_header.startswith("Bearer "):
+        return auth_header[7:]  # Remove "Bearer " prefix
+    return None
+
 
 @app.get("/")
 def read_root():
@@ -52,10 +75,12 @@ async def get_stats(
     bg_color: Optional[str] = None,
     title_color: Optional[str] = None,
     text_color: Optional[str] = None,
-    border_color: Optional[str] = None,
-    animations_enabled: bool = True
+    border_color: Optional[str] = None
 ):
-    data = github_api.get_live_github_data(username) or github_api.get_mock_data(username)
+    # Get optional token from Authorization header for higher rate limits
+    token = get_token_from_header(request)
+    
+    data = github_api.get_live_github_data(username, token) or github_api.get_mock_data(username)
     
     show_options = {
         "stars": not hide_stars,
@@ -130,7 +155,6 @@ async def get_recent(
     request: Request,
     username: str,
     theme: str = "Default",
-    token: Optional[str] = None,
     bg_color: Optional[str] = None,
     title_color: Optional[str] = None,
     text_color: Optional[str] = None,
@@ -140,6 +164,10 @@ async def get_recent(
     # It just needs the username. github_api.get_live_github_data is not strictly needed 
     # unless we want to use shared logic or mock data fallback, 
     # but recent_activity_card.draw_recent_activity_card takes `{'username': ...}`.
+    
+    # SECURITY FIX: Get token from Authorization header instead of URL parameter
+    # This prevents token exposure in logs, browser history, and proxy logs
+    token = get_token_from_header(request)
     
     custom_colors = parse_colors(bg_color, title_color, text_color, border_color)
     svg_content = recent_activity_card.draw_recent_activity_card({'username': username}, theme, custom_colors=custom_colors, token=token)


### PR DESCRIPTION
fixed #135 
**Changes Made:**

1. Added `get_token_from_header()` helper function to securely extract tokens from Authorization header
2. Removed `token` parameter from `/api/recent` endpoint URL
3. Updated `/api/stats` endpoint to support optional token via header
4. Token now uses standard `Authorization: Bearer <token>` format
5. Removed duplicate `animations_enabled` parameter bug

**Security Improvements:**
- Tokens no longer exposed in URLs
- Not logged in server/proxy logs
- Not saved in browser history
- Standard OAuth2 Bearer token format
- Backward compatible (works without token)

**Usage:**
```bash
# Without token (rate limited)
curl https://api.example.com/api/recent?username=torvalds

# With token (higher limits)
curl -H "Authorization: Bearer ghp_xxxx" https://api.example.com/api/recent?username=torvalds
```