### PR TITLE
Fix: Remove duplicate animations_enabled parameters in API endpoints

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -52,8 +52,7 @@ async def get_stats(
     bg_color: Optional[str] = None,
     title_color: Optional[str] = None,
     text_color: Optional[str] = None,
-    border_color: Optional[str] = None,
-    animations_enabled: bool = True
+    border_color: Optional[str] = None
 ):
     data = github_api.get_live_github_data(username) or github_api.get_mock_data(username)
     
@@ -107,8 +106,7 @@ async def get_contributions(
     text_color: Optional[str] = None,
     border_color: Optional[str] = None,
     start_date: Optional[str] = None,
-    end_date: Optional[str] = None,
-    animations_enabled: bool = True
+    end_date: Optional[str] = None
 ):
     data = github_api.get_live_github_data(username) or github_api.get_mock_data(username)
     custom_colors = parse_colors(bg_color, title_color, text_color, border_color)


### PR DESCRIPTION
fixed #136

Fixed:
Removed duplicate animations_enabled parameter in /api/stats endpoint
Removed duplicate animations_enabled parameter in /api/contributions endpoint
Impact:

Cleaner code
No more confusion about which parameter is used
Prevents potential bugs from conflicting default values
Better code maintainability