### PR TITLE
fix: Implement st.form to debounce GitHub username fetches (Resolves #171)

### DIFF
--- a/app.py
+++ b/app.py
@@ -63,8 +63,23 @@ with st.sidebar:
     
     # Form to debounce username input and prevent API calls on every keystroke
     with st.form(key='user_input_form'):
-        username = st.text_input("GitHub Username", value="torvalds")
+        username_input = st.text_input("GitHub Username", value="torvalds")
         submit_button = st.form_submit_button(label='Fetch Stats')
+    
+    # Initialize session state for username if not exists
+    if "username" not in st.session_state:
+        st.session_state.username = username_input
+    
+    # Handle form submission
+    if submit_button:
+        if not username_input or not username_input.strip():
+            st.warning("Please enter a GitHub username")
+        else:
+            st.session_state.username = username_input.strip()
+            st.rerun()
+    
+    # Use the username from session state
+    username = st.session_state.username
     
     st.header("2. Global Style")
     
@@ -182,7 +197,11 @@ def load_data(user, token=None, _cache_version="v2"):  # Added version to force 
         d = github_api.get_mock_data(user)
     return d
 
-data = load_data(username if username else "torvalds", github_token if github_token else None)
+# Only load data if we have a valid username in session state
+if st.session_state.get("username"):
+    data = load_data(st.session_state.username, github_token if github_token else None)
+else:
+    data = None
 
 # Ensure data is not None
 if data is None:

--- a/app.py
+++ b/app.py
@@ -60,7 +60,11 @@ st.markdown("### Design your GitHub Stats. Copy the Code. Done.")
 # --- Sidebar Controls ---
 with st.sidebar:
     st.header("1. Identify")
-    username = st.text_input("GitHub Username", value="torvalds")
+    
+    # Form to debounce username input and prevent API calls on every keystroke
+    with st.form(key='user_input_form'):
+        username = st.text_input("GitHub Username", value="torvalds")
+        submit_button = st.form_submit_button(label='Fetch Stats')
     
     st.header("2. Global Style")
     

--- a/app.py
+++ b/app.py
@@ -199,7 +199,12 @@ def load_data(user, token=None, _cache_version="v2"):  # Added version to force 
 
 # Only load data if we have a valid username in session state
 if st.session_state.get("username"):
-    data = load_data(st.session_state.username, github_token if github_token else None)
+    try:
+        with st.spinner(f'Fetching GitHub data for {st.session_state.username}...'):
+            data = load_data(st.session_state.username, github_token if github_token else None)
+    except Exception as e:
+        st.error(f"Failed to fetch data: {e}")
+        data = None
 else:
     data = None
 


### PR DESCRIPTION
### Description
This PR addresses Issue #171 by preventing Streamlit from eagerly re-running the app and hitting the GitHub API on every keystroke in the username input field.

### Changes Made
* **Implemented `st.form`:** Wrapped the username `st.text_input` and a new `st.form_submit_button` in a form.
* **Session State Management:** The username is now stored in `st.session_state` only upon form submission, ensuring the data persists when users interact with other UI elements (like theme dropdowns).
* **UX Improvements:** * Added `st.warning` validation to prevent submitting blank usernames.
  * Added `st.spinner` to provide visual feedback while the GitHub API data is being fetched.

### Testing
- [x] Verified typing in the input field does NOT trigger an API call.
- [x] Verified pressing Enter or clicking "Fetch Stats" successfully loads the data.
- [x] Verified changing a theme *after* fetching a user does not trigger a re-fetch.