### PR TITLE
feat: add compact card layout variant for stats and repo cards (Resolves #164)

### DIFF
--- a/app.py
+++ b/app.py
@@ -379,9 +379,11 @@ with tab1:
     show_followers = c4.checkbox("Followers", True)
 
     show_ops = {"stars": show_stars, "commits": show_commits, "repos": show_repos, "followers": show_followers}
+        # Compact layout toggle (Issue #164)
+    compact_layout = st.checkbox("📐 Compact Layout", value=False, help="Slim 300x120 card — fit multiple cards in one README row")
 
     # Pass selected_theme string to support theme-specific logic (e.g. Glass)
-    svg_bytes = stats_card.draw_stats_card(data, selected_theme, show_ops, custom_colors, animations_enabled)
+    svg_bytes = stats_card.draw_stats_card(data, selected_theme, show_ops, custom_colors, animations_enabled, compact=compact_layout)
     render_tab(svg_bytes, "stats", username, selected_theme, custom_colors, hide_params=show_ops, code_template=f"[![{username}'s Stats]({{url}})](https://github.com/{{username}})", output_format=output_format)
     
     # Prepare the SVG string from your generator
@@ -476,8 +478,8 @@ with tab3:
     if exclude_forks and "top_repos" in filtered_data:
         filtered_data["top_repos"] = [r for r in filtered_data["top_repos"] if not r.get("is_fork", False)]
     
-    # Generate card - Pass selected_theme string
-    svg_bytes = repo_card.draw_repo_card(filtered_data, selected_theme, custom_colors, sort_by=sort_by, limit=repo_limit)
+    compact_repo = st.checkbox("📐 Compact Layout", value=False, help="Slim 300px card — fit multiple cards in one README row", key="compact_repo")
+    svg_bytes = repo_card.draw_repo_card(filtered_data, selected_theme, custom_colors, sort_by=sort_by, limit=repo_limit, compact=compact_repo)
     render_tab(svg_bytes, "repos", username, selected_theme, custom_colors, code_template="![Top Repos]({url})", output_format=output_format)
 
 with tab4:

--- a/generators/repo_card.py
+++ b/generators/repo_card.py
@@ -2,7 +2,7 @@ import svgwrite
 from themes.styles import THEMES
 from .svg_base import create_svg_base
 
-def draw_repo_card(data, theme_name="Default", custom_colors=None, sort_by="stars", limit=5):
+def draw_repo_card(data, theme_name="Default", custom_colors=None, sort_by="stars", limit=5, compact=False):
     """
     Generates the Top Repositories Card SVG.
     data: dict with 'top_repos' list containing repo data
@@ -23,6 +23,97 @@ def draw_repo_card(data, theme_name="Default", custom_colors=None, sort_by="star
     
     # Apply limit
     repos = repos[:limit]
+
+    # ── Compact Layout 
+    if compact:
+        compact_width  = 300
+        compact_height = 30 + (len(repos) * 28) + 10
+        
+        from themes.styles import THEMES
+        if isinstance(theme_name, dict):
+            theme = theme_name.copy()
+        else:
+            theme = THEMES.get(theme_name, THEMES["Default"]).copy()
+            if custom_colors:
+                theme.update(custom_colors)
+
+        bg_col     = theme.get("bg_color",     "#0d1117")
+        border_col = theme.get("border_color", "#30363d")
+        title_col  = theme.get("title_color",  "#58a6ff")
+        text_col   = theme.get("text_color",   "#c9d1d9")
+        icon_col   = theme.get("icon_color",   "#8b949e")
+        font       = theme.get("font_family",  "Segoe UI, Ubuntu, Sans-Serif")
+
+        c_dwg = svgwrite.Drawing(size=(compact_width, compact_height))
+        c_dwg.viewbox(0, 0, compact_width, compact_height)
+
+        # Background
+        c_dwg.add(c_dwg.rect(
+            insert=(0, 0), size=(compact_width, compact_height),
+            rx=10, ry=10,
+            fill=bg_col, stroke=border_col, stroke_width=1.5
+        ))
+
+        # Title
+        sort_labels = {"stars": "Top Repos ⭐", "forks": "Top Repos 🔱", "updated": "Top Repos 🕐"}
+        c_dwg.add(c_dwg.text(
+            sort_labels.get(sort_by, "Top Repos"),
+            insert=(12, 20),
+            fill=title_col, font_size=10,
+            font_family=font, font_weight="bold"
+        ))
+
+        # Divider
+        c_dwg.add(c_dwg.line(
+            start=(12, 25), end=(compact_width - 12, 25),
+            stroke=border_col, stroke_width=0.8
+        ))
+
+        # Repo rows
+        for i, repo in enumerate(repos[:5]):
+            y = 38 + i * 28
+            name = repo.get("name", "Unknown")[:22]
+            stars = repo.get("stars", 0)
+
+            # Repo name
+            c_dwg.add(c_dwg.text(
+                name,
+                insert=(12, y),
+                fill=text_col, font_size=9,
+                font_family=font, font_weight="bold"
+            ))
+
+            # Star dot + count
+            c_dwg.add(c_dwg.circle(
+                center=(compact_width - 45, y - 4),
+                r=3, fill="#FFD700", opacity=0.9
+            ))
+            c_dwg.add(c_dwg.text(
+                f"{stars:,}",
+                insert=(compact_width - 38, y),
+                fill=icon_col, font_size=8,
+                font_family=font
+            ))
+
+            # Language
+            lang = repo.get("language") or ""
+            if lang:
+                c_dwg.add(c_dwg.text(
+                    lang[:12],
+                    insert=(12, y + 12),
+                    fill=icon_col, font_size=7,
+                    font_family=font, opacity=0.7
+                ))
+
+            # Separator
+            if i < len(repos) - 1:
+                c_dwg.add(c_dwg.line(
+                    start=(12, y + 18), end=(compact_width - 12, y + 18),
+                    stroke=border_col, stroke_width=0.5, opacity=0.4
+                ))
+
+        return c_dwg.tostring()
+    # ── End Compact Layout ────────────────────────────────────────────────
     
     if not repos:
         # Return empty card with message

--- a/generators/stats_card.py
+++ b/generators/stats_card.py
@@ -42,7 +42,7 @@ COUNTING_SCRIPT = """
 </script>
 """
 
-def draw_stats_card(data, theme_name="Default", show_options=None, custom_colors=None, animations_enabled=True):
+def draw_stats_card(data, theme_name="Default", show_options=None, custom_colors=None, animations_enabled=True, compact=False):
     """
     Generates the Main Stats Card SVG.
     data: dict with user stats
@@ -295,6 +295,76 @@ def draw_stats_card(data, theme_name="Default", show_options=None, custom_colors
         
         return dwg.tostring()
     
+        # ── Compact Layout (Issue #164) ──────────────────────────────────────
+    if compact:
+        compact_width = 300
+        compact_height = 120
+        username = data.get("username", "user")
+
+        c_dwg = svgwrite.Drawing(size=(compact_width, compact_height))
+        c_dwg.viewbox(0, 0, compact_width, compact_height)
+
+        bg_col     = theme.get("bg_color",     "#0d1117")
+        border_col = theme.get("border_color", "#30363d")
+        title_col  = theme.get("title_color",  "#58a6ff")
+        text_col   = theme.get("text_color",   "#c9d1d9")
+        icon_col   = theme.get("icon_color",   "#8b949e")
+        font       = theme.get("font_family",  "Segoe UI, Ubuntu, Sans-Serif")
+
+        # Background + border
+        c_dwg.add(c_dwg.rect(
+            insert=(0, 0), size=(compact_width, compact_height),
+            rx=10, ry=10,
+            fill=bg_col, stroke=border_col, stroke_width=1.5
+        ))
+
+        # Title
+        c_dwg.add(c_dwg.text(
+            f"{username}'s Stats",
+            insert=(12, 22),
+            fill=title_col, font_size=11,
+            font_family=font, font_weight="bold"
+        ))
+
+        # Divider
+        c_dwg.add(c_dwg.line(
+            start=(12, 28), end=(compact_width - 12, 28),
+            stroke=border_col, stroke_width=0.8
+        ))
+
+        # Stats in 2x2 grid
+        stats_map = [
+            ("stars",     "⭐ Stars",   data.get("total_stars",   0)),
+            ("commits",   "🔨 Commits", data.get("total_commits", 0)),
+            ("repos",     "📦 Repos",   data.get("public_repos",  0)),
+            ("followers", "👥 Follows", data.get("followers",     0)),
+        ]
+
+        visible = [(k, l, v) for k, l, v in stats_map if show_options.get(k, True)]
+
+        col_w  = compact_width // 2
+        row_h  = 36
+        start_y = 42
+
+        for i, (key, label, value) in enumerate(visible[:4]):
+            col = i % 2
+            row = i // 2
+            x = col * col_w + 12
+            y = start_y + row * row_h
+
+            c_dwg.add(c_dwg.text(
+                label, insert=(x, y),
+                fill=icon_col, font_size=8,
+                font_family=font
+            ))
+            c_dwg.add(c_dwg.text(
+                str(value), insert=(x, y + 16),
+                fill=text_col, font_size=13,
+                font_family=font, font_weight="bold"
+            ))
+
+        return c_dwg.tostring()
+    # ── End Compact Layout ────────────────────────────────────────────────
     
     # Title
     font_family = theme["font_family"]


### PR DESCRIPTION
- Contributing on behalf on NSoC'26

## 📐 Compact Card Layout Variant

Resolves #164

## Problem Before
Stats and Repo cards used large fixed viewBox sizes (450px, 500px wide),
making it impossible to fit multiple cards side-by-side in a README row.

## What's Changed

### `generators/stats_card.py`
- Added `compact=False` parameter to `draw_stats_card()`
- Compact mode renders a slim **300×120** SVG
- Stats displayed in a **2×2 grid** layout
- Uses same theme colors as the full card

### `generators/repo_card.py`
- Added `compact=False` parameter to `draw_repo_card()`
- Compact mode renders a slim **300px wide** card
- Shows repo name + ⭐ star count + language in tight rows
- Dynamic height based on number of repos shown

### `app.py`
- Added **📐 Compact Layout** checkbox in **Main Stats** tab
- Added **📐 Compact Layout** checkbox in **Top Repositories** tab
- Passes `compact=True` to generators when toggled

## Normal vs Compact

| Mode | Stats Card | Repo Card |
|---|---|---|
| Normal | 450px wide, single column | 500px wide, detailed rows |
| Compact | 300×120, 2×2 grid | 300px wide, tight list |

## How to Test
1. Go to **Main Stats** tab → tick **📐 Compact Layout** → card shrinks to 2×2 grid
2. Go to **Top Repositories** tab → tick **📐 Compact Layout** → card shrinks to slim list
3. Both cards use correct theme colors when compact mode is on

## Screenshots
<img width="1919" height="866" alt="image" src="https://github.com/user-attachments/assets/d9ac9faa-018a-4f2f-9df3-d1df847c6b02" />

<img width="1918" height="858" alt="image" src="https://github.com/user-attachments/assets/a94bbdd2-a78f-40e6-80ad-d50e7c839699" />


## Files Changed
- `generators/stats_card.py` — compact block added
- `generators/repo_card.py` — compact block added  
- `app.py` — two compact checkboxes added

@devanshi14malhotra please reivew 