### PR TITLE
feat: add explicit API error messaging with fallback SVG card (Resolves #165)

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ from generators import stats_card, lang_card, contrib_card, badge_generator, rec
 from utils import github_api
 from utils.cache import clear_cache as clear_ttl_cache
 from themes.styles import THEMES, get_all_themes, CUSTOM_THEMES
+from utils.error_card import draw_error_card
 from generators.visual_elements import (
     emoji_element,
     gif_element,
@@ -191,8 +192,7 @@ effective_github_token = _github_from_sidebar or _settings.github_token_value()
 def load_data(user, token=None, _cache_version="v3"):  # bump when auth/cache semantics change
     d = github_api.get_live_github_data(user, token)
     if not d:
-        st.warning("Using mock data (API limits).")
-        d = github_api.get_mock_data(user)
+        return None   # Signal the caller — don't silently use mock data
     return d
 
 data = load_data(username if username else "torvalds", effective_github_token or None)
@@ -206,7 +206,23 @@ if not effective_github_token:
 
 # Ensure data is not None
 if data is None:
-    data = {}
+    if effective_github_token:
+        _err_type = "invalid_user"
+        _err_type_msg = "Username not found — check spelling."
+    else:
+        _err_type = "rate_limit"
+        _err_type_msg = "GitHub API rate limit reached — add a `GITHUB_TOKEN` in the sidebar."
+
+    _err_svg = draw_error_card(_err_type, username=username if username else "user")
+
+    st.error(f"⚠️ **Could not load GitHub data.** {_err_type_msg}")
+    st.markdown(
+        f'<div style="max-width:450px; margin-top:12px;">{_err_svg}</div>',
+        unsafe_allow_html=True
+    )
+    st.info("💡 Add a `GITHUB_TOKEN` in the sidebar to fix rate limit issues.")
+    st.stop()
+
 
 # Ensure backward compatibility with old cached data
 if "top_repos" not in data:

--- a/utils/error_card.py
+++ b/utils/error_card.py
@@ -1,0 +1,120 @@
+# utils/error_card.py
+# Resolves Issue #165 — visual fallback SVG card for API errors
+
+import svgwrite
+
+
+def draw_error_card(error_type: str = "rate_limit", username: str = "user", message: str = "") -> str:
+    """
+    Returns a themed SVG card explaining why real data could not be loaded.
+
+    error_type options:
+        "rate_limit"   — GitHub API rate limit hit
+        "invalid_user" — Username does not exist
+        "unknown"      — Any other failure
+    """
+
+    WIDTH, HEIGHT = 450, 160
+
+    config = {
+        "rate_limit": {
+            "icon":    "⏳",
+            "title":   "API Rate Limit Reached",
+            "line1":   "GitHub's API limit was hit for this session.",
+            "line2":   "Add a GITHUB_TOKEN in the sidebar or .env",
+            "line3":   "to increase the limit from 60 → 5,000 req/hr.",
+            "bg":      "#161b22",
+            "border":  "#f0883e",
+            "title_c": "#f0883e",
+            "text_c":  "#c9d1d9",
+        },
+        "invalid_user": {
+            "icon":    "❌",
+            "title":   f'User "{username}" Not Found',
+            "line1":   "No GitHub account exists for this username.",
+            "line2":   "Double-check the spelling and try again.",
+            "line3":   "",
+            "bg":      "#161b22",
+            "border":  "#f85149",
+            "title_c": "#f85149",
+            "text_c":  "#c9d1d9",
+        },
+        "unknown": {
+            "icon":    "⚠️",
+            "title":   "Could Not Load GitHub Data",
+            "line1":   message or "An unexpected error occurred.",
+            "line2":   "Check your internet connection and try again.",
+            "line3":   "",
+            "bg":      "#161b22",
+            "border":  "#e3b341",
+            "title_c": "#e3b341",
+            "text_c":  "#c9d1d9",
+        },
+    }
+
+    c = config.get(error_type, config["unknown"])
+
+    dwg = svgwrite.Drawing(size=(WIDTH, HEIGHT))
+    dwg.viewbox(0, 0, WIDTH, HEIGHT)
+
+    # Background
+    dwg.add(dwg.rect(
+        insert=(0, 0), size=(WIDTH, HEIGHT),
+        rx=12, ry=12,
+        fill=c["bg"], stroke=c["border"], stroke_width=2
+    ))
+
+    # Top accent bar
+    dwg.add(dwg.rect(
+        insert=(0, 0), size=(WIDTH, 4),
+        rx=2, ry=2, fill=c["border"]
+    ))
+
+    # Icon
+    dwg.add(dwg.text(
+        c["icon"],
+        insert=(20, 42),
+        font_size=22,
+        font_family="Segoe UI Emoji, sans-serif"
+    ))
+
+    # Title
+    dwg.add(dwg.text(
+        c["title"],
+        insert=(52, 42),
+        fill=c["title_c"],
+        font_size=14,
+        font_family="Segoe UI, Ubuntu, sans-serif",
+        font_weight="bold"
+    ))
+
+    # Divider
+    dwg.add(dwg.line(
+        start=(20, 55), end=(WIDTH - 20, 55),
+        stroke=c["border"], stroke_width=0.8, opacity=0.5
+    ))
+
+    # Body lines
+    for i, line in enumerate([c["line1"], c["line2"], c["line3"]]):
+        if line:
+            dwg.add(dwg.text(
+                line,
+                insert=(20, 78 + i * 22),
+                fill=c["text_c"],
+                font_size=11,
+                font_family="Segoe UI, Ubuntu, sans-serif",
+                opacity=0.9
+            ))
+
+    # Footer hint
+    dwg.add(dwg.text(
+        "GitCanvas — gitcanvas-dm.streamlit.app",
+        insert=(WIDTH - 20, HEIGHT - 12),
+        fill=c["text_c"],
+        font_size=9,
+        font_family="Segoe UI, Ubuntu, sans-serif",
+        text_anchor="end",
+        opacity=0.4
+    ))
+
+    return dwg.tostring()


### PR DESCRIPTION
## Description

- Contributing Under the NSoC'26

##  Better GitHub API Error Messaging

Resolves #165

## Problem Before
When GitHub API failed (rate limit or invalid username), the app
silently fell back to `get_mock_data()` with just a small warning,
making users think they were seeing real data.

## What's Changed

### `utils/error_card.py` (new file)
- New `draw_error_card()` function that generates a themed SVG card
- Handles 3 error types:
  - `rate_limit` 🟠 — orange card when API limit is hit
  - `invalid_user` 🔴 — red card when username doesn't exist
  - `unknown` 🟡 — yellow card for any other failure
- Each card shows icon, title, explanation, and actionable fix hint

### `app.py`
- Removed silent `get_mock_data()` fallback
- `load_data()` now returns `None` on failure instead of fake data
- Added smart error type detection:
  - Has token + no data → `invalid_user`
  - No token + no data → `rate_limit`
- Shows `st.error()` message + visual SVG error card + `st.info()` tip
- Calls `st.stop()` to prevent empty cards from rendering below

## Error Cards Preview

| Error Type | Trigger | Card Color |
|---|---|---|
| Rate Limit | No token, too many requests | 🟠 Orange |
| Invalid User | Wrong/fake username | 🔴 Red |
| Unknown | Unexpected failure | 🟡 Yellow |

## How to Test
1. Type a fake username like `xthisisnotarealuser99999xyz`
   → Red card: "User Not Found"
2. Remove GitHub token + force `return None` in `load_data()`
   → Orange card: "API Rate Limit Reached"
3. Real username with valid token
   → Normal cards load correctly 

## Screenshots
<img width="1907" height="865" alt="image" src="https://github.com/user-attachments/assets/94c50e41-c73f-4133-9052-3d0ae515bab3" />


## Files Changed
- `utils/error_card.py` — new file, SVG error card generator
- `app.py` — error detection and display logic
