### PR TITLE
fix: debounce username input with st.form to prevent per-keystroke API calls (Resolves #171)

### DIFF
--- a/app.py
+++ b/app.py
@@ -70,7 +70,29 @@ st.markdown("### Design your GitHub Stats. Copy the Code. Done.")
 # --- Sidebar Controls ---
 with st.sidebar:
     st.header("1. Identify")
-    username = st.text_input("GitHub Username", value="torvalds")
+     # Wrapping in st.form prevents API re-fetch on every keystroke.
+    # Data only loads when user clicks "Load Profile" or presses Enter.
+    with st.form(key="username_form"):
+        username = st.text_input(
+            "GitHub Username",
+            value=st.session_state.get("last_username", "torvalds"),
+            placeholder="e.g. torvalds",
+            help="Press Enter or click Load Profile to fetch data"
+        )
+        submitted = st.form_submit_button(
+            "🔍 Load Profile",
+            use_container_width=True,
+            type="primary"
+        )
+
+    # Only update the active username when form is submitted
+    if submitted:
+        st.session_state["last_username"] = username
+
+    # Use last confirmed username — avoids mid-typing API calls
+    username = st.session_state.get("last_username", "torvalds")
+    # ── End debounce fix ─────────────────────────────────────────────────
+
     
     st.header("2. Global Style")
     


### PR DESCRIPTION
## Description

- Contributing Under the NSoC'26

## ⌨️ Debounce Username Real-time Data Fetches

<img width="1919" height="875" alt="image" src="https://github.com/user-attachments/assets/5074a90f-5ae5-4f60-b525-623f6cf4c6ec" />


Resolves #171

## Problem Before
`st.text_input("GitHub Username")` caused Streamlit to re-run 
and re-fetch GitHub API data on **every single keystroke**.
Typing "torvalds" (8 chars) = 8 API calls wasted.

## Solution
Wrapped the username input in `st.form` with a **" Load Profile"** 
submit button. API data only fetches when the user explicitly 
submits — not during typing.

## How It Works
- `st.form` batches all input changes until submit
- `st.session_state["last_username"]` stores the last confirmed username
- App always renders using the last submitted username
- No data loss — current username persists across reruns

## Before vs After

| | Before | After |
|---|---|---|
| Typing "torvalds" | 8 API calls | 0 API calls |
| Pressing Enter / clicking button | 1 API call | 1 API call  |
| GitHub rate limit impact | High | Minimal |

## Files Changed
- `app.py` — username input wrapped in `st.form`


@devanshi14malhotra please review 