### PR TITLE
fix: theme tag filter incorrectly shows themes without tags (fixes #199)

### DIFF
--- a/app.py
+++ b/app.py
@@ -107,15 +107,18 @@ with st.sidebar:
         if not selected_tags:
             tag_match = True
         elif not theme_tags:
-            tag_match = True
+            tag_match = False  # Hide themes without tags when tag filter is active
         else:
             tag_match = any(tag in theme_tags for tag in selected_tags)
         return search_match and tag_match
 
-    filtered_theme_options = [
+    # Filter from all_themes, then reorder to match theme_options (predefined first, custom last)
+    filtered_set = {
         name for name, props in all_themes.items()
         if matches_filter(name, props)
-    ] or theme_options  # fallback to all if nothing matches
+    }
+    # Preserve original ordering: predefined themes first, then custom
+    filtered_theme_options = [name for name in theme_options if name in filtered_set] or theme_options  # fallback to all if nothing matches
 
     selected_theme = st.selectbox("Select Theme", filtered_theme_options)
     


### PR DESCRIPTION
## Fixes #199

### Bug 1: Themes without tags pass tag filter
When a user selects tag filters (e.g. "dark", "gaming"), themes that have no  field (Ocean, Retro, and any custom themes) were incorrectly shown because  had:

```python
elif not theme_tags:
    tag_match = True  # Wrong!
```

**Fix**: Changed to `tag_match = False` so tagless themes are hidden when a tag filter is active.

### Bug 2: Dropdown order changes on filter
`filtered_theme_options` iterated over `all_themes.items()` (dict), which doesn't guarantee the predefined-first ordering. When filtering was active, the dropdown order shifted.

**Fix**: Filter using a set, then select from `theme_options` list to preserve the predefined-first, custom-last ordering.

### Testing
1. Open Streamlit app → Global Style → Filter Themes
2. Select a tag filter (e.g. "dark") → Ocean, Retro should no longer appear
3. Clear filter → All themes reappear in consistent order
4. Search for "ocean" → Ocean appears in results (search still works independently)