### PR TITLE
feat: add GitHub API rate limit status indicator in sidebar

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,6 +22,10 @@ from generators.visual_elements import (
 )
 from theme_gallery import render_theme_gallery 
 
+import requests
+from datetime import datetime
+
+
 
 # Load environment variables
 load_dotenv()
@@ -65,6 +69,44 @@ st.markdown("""
 st.title("GitCanvas: Profile Architect 🛠️")
 st.markdown("### Design your GitHub Stats. Copy the Code. Done.")
 
+
+def get_rate_limit_status(token: str = None) -> dict | None:
+    """Fetch GitHub API rate limit status."""
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    if token and token.strip():
+        headers["Authorization"] = f"token {token.strip()}"
+
+    try:
+        response = requests.get("https://api.github.com/rate_limit", headers=headers, timeout=10)
+        
+        if response.status_code == 200:
+            data = response.json()
+            core = data["resources"]["core"]
+            
+            remaining = core["remaining"]
+            limit = core["limit"]
+            reset_ts = core["reset"]
+            
+            reset_time = datetime.fromtimestamp(reset_ts)
+            minutes_left = max(0, int((reset_time - datetime.now()).total_seconds() / 60))
+
+            if remaining > limit * 0.65:
+                color = "🟢"
+            elif remaining > limit * 0.25:
+                color = "🟠"
+            else:
+                color = "🔴"
+
+            return {
+                "remaining": remaining,
+                "limit": limit,
+                "reset_in": minutes_left,
+                "color": color
+            }
+    except:
+        pass
+    
+    return None
 
 
 # --- Sidebar Controls ---
@@ -224,6 +266,26 @@ with st.sidebar:
         type="password",
         help="Paste a token here, or set GITHUB_TOKEN in a .env file in the project root. Sidebar value overrides .env.",
     )
+
+    # ==================== RATE LIMIT STATUS INDICATOR ====================
+    st.markdown("**Rate Limit Status**")
+
+    rate_info = get_rate_limit_status(github_token)
+
+    if rate_info:
+        col1, col2 = st.columns([0.8, 3.2])
+        with col1:
+            st.markdown(f"{rate_info['color']}", unsafe_allow_html=True)
+        with col2:
+            st.markdown(f"**{rate_info['remaining']} / {rate_info['limit']}** remaining")
+
+        st.caption(f"🔄 Resets in **{rate_info['reset_in']}** minutes")
+
+        if rate_info['remaining'] < 200:
+            st.warning("⚠️ Rate limit is getting low. Consider using a token with higher limits.", icon="⚠️")
+    else:
+        st.caption("Using anonymous access → **60 requests/hour**")
+    # =====================================================================
     
     # Animation toggle
     animations_enabled = st.checkbox("Enable Animations", value=False, help="Enable SVG animations for cards that support it")

--- a/utils/github_utils.py
+++ b/utils/github_utils.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Optional
 from collections import Counter
 
 from utils.logger import setup_logger
+from datetime import datetime
 
 logger = setup_logger(__name__)
 
@@ -191,6 +192,60 @@ def fetch_github_stats_detailed(username: str, github_token: Optional[str] = Non
     except Exception as e:
         logger.error(f"Error with GraphQL query: {e}")
         return fetch_github_stats(username)  # Fallback
+
+
+def get_rate_limit_status(token: str = None) -> dict:
+    """
+    Fetch current GitHub API rate limit status.
+    Works with or without token.
+    """
+    headers = {}
+    if token:
+        headers["Authorization"] = f"token {token}"
+
+    try:
+        # Use the dedicated rate limit endpoint (doesn't count against your limit)
+        url = "https://api.github.com/rate_limit"
+        response = requests.get(url, headers=headers, timeout=10)
+        
+        if response.status_code == 200:
+            data = response.json()
+            core = data.get("resources", {}).get("core", {})
+            
+            remaining = core.get("remaining", 0)
+            limit = core.get("limit", 60)
+            reset_timestamp = core.get("reset", 0)
+            
+            # Calculate time until reset
+            if reset_timestamp:
+                reset_time = datetime.fromtimestamp(reset_timestamp)
+                minutes_left = max(0, int((reset_time - datetime.now()).total_seconds() / 60))
+            else:
+                minutes_left = 0
+
+            # Determine status color
+            if remaining > limit * 0.7:
+                status_color = "🟢"   # Good
+                status_text = "Good"
+            elif remaining > limit * 0.3:
+                status_color = "🟠"   # Warning
+                status_text = "Warning"
+            else:
+                status_color = "🔴"   # Critical
+                status_text = "Critical"
+
+            return {
+                "remaining": remaining,
+                "limit": limit,
+                "reset_in_minutes": minutes_left,
+                "status_color": status_color,
+                "status_text": status_text,
+                "used": limit - remaining
+            }
+        else:
+            return None
+    except Exception:
+        return None
 
 
 # For testing


### PR DESCRIPTION
Added rate limit indicator below the GitHub Token input field.

Features:
- Shows remaining requests / total limit (e.g. 4994 / 5000)
- Displays time until reset
- Color-coded status (🟢 🟠 🔴)
- Warning when rate limit is low
- Works with and without token

Tested locally.