### PR TITLE
feat: Add Yearly Calendar Heatmap Card with Live Color Pickers & 365-Day Data

### DIFF
--- a/app.py
+++ b/app.py
@@ -306,11 +306,11 @@ if custom_colors:
 
 
 # --- Layout: Tabs ---
-tab1, tab2, tab3, tab4, tab5, tab6, tab7, tab8, tab9, tab10, tab11, tab12 = st.tabs([
+tab1, tab2, tab3, tab4, tab5, tab6, tab7, tab8, tab9, tab10, tab11, tab12, tab13 = st.tabs([
     "Main Stats", "Languages", "Top Repositories", "Contributions",
     "🔥 GitHub Streak", "🔗 Social Links", "Icons & Badges",
     "🔥 AI Roast", "Recent Activity", "✨ Visual Elements",
-    "🏆 Trophy", "🎨 Theme Gallery"    # ← NEW TAB
+    "🏆 Trophy", "🎨 Theme Gallery", "📅 Calendar Heatmap"    # ← NEW TAB
 ])
 
 def show_code_area(code_content, label="Markdown Code"):
@@ -856,3 +856,110 @@ with tab12:
     if chosen_theme:
         st.session_state["gallery_selected_theme"] = chosen_theme
         st.rerun()
+
+# ── Calendar Heatmap Card ─────────────────────────────────────────────
+with tab13:
+    st.subheader("📅 Yearly Calendar Heatmap")
+    st.markdown("An enhanced 365-day calendar heatmap with granular level control and custom colors.")
+
+    # ── Row 1: Intensity + Date Range ────────────────────────────────────
+    col1, col2 = st.columns([1, 1])
+    with col1:
+        hm_level_control = st.selectbox(
+            "Intensity Levels",
+            ["auto", "none", "low", "medium", "high"],
+            index=0,
+            help="auto: 4 levels scaled to data  |  low: active/inactive only  |  none: all empty"
+        )
+    with col2:
+        heatmap_date_option = st.selectbox(
+            "Period",
+            ["Last Year", "Current Year", "Custom Range"],
+            index=0
+        )
+
+    # Custom date range inputs (only shown when needed)
+    heatmap_date_range = None
+    if heatmap_date_option == "Custom Range":
+        from datetime import datetime, timedelta, timezone
+        hm_today = datetime.now(timezone.utc).date()
+        cd1, cd2 = st.columns(2)
+        hm_start = cd1.date_input("Start Date", value=hm_today - timedelta(days=364), key="hm_start")
+        hm_end   = cd2.date_input("End Date",   value=hm_today,                       key="hm_end")
+        heatmap_date_range = {
+            "start": hm_start.strftime("%Y-%m-%d"),
+            "end":   hm_end.strftime("%Y-%m-%d"),
+        }
+    elif heatmap_date_option == "Current Year":
+        from datetime import datetime, timezone
+        hm_today = datetime.now(timezone.utc).date()
+        heatmap_date_range = {
+            "start": datetime(hm_today.year, 1, 1).date().strftime("%Y-%m-%d"),
+            "end":   hm_today.strftime("%Y-%m-%d"),
+        }
+
+    # ── Row 2: Intensity color pickers (always visible, pre-filled with defaults) ──
+    st.markdown("**Intensity Colors** — change any to customise the palette")
+    cc1, cc2, cc3, cc4, cc5 = st.columns(5)
+    hm_color0 = cc1.color_picker("Level 0 (None)",   "#161b22", key="hm_c0")
+    hm_color1 = cc2.color_picker("Level 1 (Low)",    "#0e4429", key="hm_c1")
+    hm_color2 = cc3.color_picker("Level 2 (Med)",    "#006d32", key="hm_c2")
+    hm_color3 = cc4.color_picker("Level 3 (High)",   "#26a641", key="hm_c3")
+    hm_color4 = cc5.color_picker("Level 4 (Max)",    "#39d353", key="hm_c4")
+    hm_level_colors = [hm_color0, hm_color1, hm_color2, hm_color3, hm_color4]
+
+    # ── Render live (no button needed) ───────────────────────────────────
+    try:
+        heatmap_svg = contrib_card.draw_calendar_heatmap_card(
+            data,
+            selected_theme,
+            custom_colors or None,
+            date_range=heatmap_date_range,
+            animations_enabled=animations_enabled,
+            level_control=hm_level_control,
+            level_colors=hm_level_colors,
+        )
+
+        hm_col1, hm_col2 = st.columns([1.5, 1])
+        with hm_col1:
+            heatmap_b64 = base64.b64encode(heatmap_svg.encode("utf-8")).decode("utf-8")
+            st.markdown(
+                f'<img src="data:image/svg+xml;base64,{heatmap_b64}" '
+                f'style="max-width:100%; box-shadow:0 4px 6px rgba(0,0,0,0.3); border-radius:10px;"/>',
+                unsafe_allow_html=True
+            )
+            st.download_button(
+                label="⬇️ Download SVG",
+                data=heatmap_svg.encode("utf-8"),
+                file_name=f"calendar_heatmap_{username}.svg",
+                mime="image/svg+xml",
+                use_container_width=True
+            )
+
+        with hm_col2:
+            st.subheader("Integration")
+            hm_params = []
+            if selected_theme != "Default":
+                hm_params.append(f"theme={selected_theme}")
+            for k, v in (custom_colors or {}).items():
+                hm_params.append(f"{k}={v.replace('#', '')}")
+            if heatmap_date_range:
+                hm_params.append(f"start_date={heatmap_date_range['start']}")
+                hm_params.append(f"end_date={heatmap_date_range['end']}")
+            if hm_level_control != "auto":
+                hm_params.append(f"level_control={hm_level_control}")
+            hm_params.append(
+                "level_colors=" + ",".join(c.replace("#", "") for c in hm_level_colors)
+            )
+            hm_params.append("heatmap=true")
+            hm_url = f"https://gitcanvas-api.vercel.app/api/contributions?{'&'.join(hm_params)}&username={username}"
+
+            hm_code = (
+                f'<a href="https://github.com/{username}"><img src="{hm_url}" alt="Calendar Heatmap"/></a>'
+                if output_format == "HTML"
+                else f"![Calendar Heatmap]({hm_url})"
+            )
+            show_code_area(hm_code, label="HTML Code" if output_format == "HTML" else "Markdown Code")
+
+    except Exception as e:
+        st.error(f"Error generating calendar heatmap: {e}")

--- a/generators/contrib_card.py
+++ b/generators/contrib_card.py
@@ -187,6 +187,222 @@ def _add_timeline_labels(dwg, weeks, cols, rows, start_x, start_y, box_size, gap
             font_family=theme["font_family"],
             opacity=0.8
         ))
+def draw_calendar_heatmap_card(
+    data,
+    theme_name="Default",
+    custom_colors=None,
+    date_range=None,
+    animations_enabled=True,
+    level_control="auto",
+    level_colors=None
+):
+    """
+    Generates an enhanced yearly Calendar Heatmap Card (365 days).
+
+    level_control: "none" | "low" | "medium" | "high" | "auto"
+    level_colors:  dict {0..4: color} or list of 5 colors
+    """
+    theme = THEMES.get(theme_name, THEMES["Default"]).copy()
+    if custom_colors:
+        theme.update(custom_colors)
+
+    # ── Layout constants ────────────────────────────────────────────────────
+    CELL      = 11   # cell size (px)
+    GAP       = 2    # gap between cells
+    STEP      = CELL + GAP
+    COLS      = 53   # weeks
+    ROWS      = 7    # days per week
+    PAD_LEFT  = 32   # room for Mon/Wed/Fri labels
+    PAD_TOP   = 52   # room for title + month labels
+    PAD_BOT   = 28   # room for legend
+    PAD_RIGHT = 16
+
+    grid_w = COLS * STEP - GAP
+    grid_h = ROWS * STEP - GAP
+    width  = PAD_LEFT + grid_w + PAD_RIGHT
+    height = PAD_TOP  + grid_h + PAD_BOT
+
+    GRID_X = PAD_LEFT
+    GRID_Y = PAD_TOP
+
+    dwg = svgwrite.Drawing(size=("100%", "100%"), viewBox=f"0 0 {width} {height}")
+
+    # Background
+    dwg.add(dwg.rect(insert=(0, 0), size=("100%", "100%"), rx=10, ry=10,
+                     fill=theme["bg_color"], stroke=theme["border_color"], stroke_width=1.5))
+
+    # Title
+    username = data.get("username", "Unknown")
+    total_commits = data.get("total_commits", 0)
+    dwg.add(dwg.text(
+        f"{username}'s Contribution Calendar",
+        insert=(PAD_LEFT, 22),
+        fill=theme["title_color"],
+        font_size=13,
+        font_family=theme.get("font_family", "Arial"),
+        font_weight="bold"
+    ))
+    dwg.add(dwg.text(
+        f"{total_commits:,} contributions in the last year",
+        insert=(PAD_LEFT, 36),
+        fill=theme["text_color"],
+        font_size=9,
+        font_family=theme.get("font_family", "Arial"),
+        opacity=0.7
+    ))
+
+    # ── Contribution data ────────────────────────────────────────────────────
+    contributions = data.get("contributions", [])
+    if date_range:
+        from utils.github_api import filter_contributions_by_date
+        contributions = filter_contributions_by_date(contributions, date_range)
+
+    date_counts = {}
+    for item in contributions:
+        d = item.get("date")
+        if not isinstance(d, str) or not d.strip():
+            continue
+        try:
+            date_counts[date.fromisoformat(d)] = item.get("count", 0)
+        except ValueError:
+            continue
+
+    today = datetime.now(timezone.utc).date()
+
+    if date_range and date_range.get("start"):
+        try:
+            start_date = date.fromisoformat(date_range["start"])
+        except Exception:
+            start_date = today - timedelta(days=364)
+    else:
+        start_date = today - timedelta(days=364)
+
+    # Align start_date to the Sunday of its week (GitHub style)
+    start_date -= timedelta(days=(start_date.weekday() + 1) % 7)
+    end_date = start_date + timedelta(days=COLS * 7 - 1)
+
+    max_count = max(date_counts.values(), default=1) or 1
+
+    # ── Color palette ────────────────────────────────────────────────────────
+    bg = theme["bg_color"]
+    is_light_bg = bg.startswith("#f") or bg.startswith("#e") or bg in ("#ffffff", "#fff")
+    default_empty = "#ebedf0" if is_light_bg else "#161b22"
+    default_palette = [
+        default_empty,
+        "#0e4429", "#006d32", "#26a641", "#39d353"
+    ]
+
+    colors = {}
+    if level_colors:
+        if isinstance(level_colors, dict):
+            colors = {int(k): v for k, v in level_colors.items()}
+        elif isinstance(level_colors, (list, tuple)) and len(level_colors) >= 5:
+            colors = {i: level_colors[i] for i in range(5)}
+    if not colors:
+        colors = {i: default_palette[i] for i in range(5)}
+
+    if level_control == "none":
+        colors = {i: colors[0] for i in range(5)}
+    elif level_control == "low":
+        colors = {0: colors[0], 1: colors[4], 2: colors[4], 3: colors[4], 4: colors[4]}
+    elif level_control == "medium":
+        colors = {0: colors[0], 1: colors[0], 2: colors[2], 3: colors[4], 4: colors[4]}
+
+    def _level(count):
+        if count <= 0:
+            return 0
+        if level_control == "none":
+            return 0
+        if level_control == "low":
+            return 4
+        ratio = count / max_count
+        if level_control == "medium":
+            return 4 if ratio > 0.5 else 2
+        # high / auto
+        if ratio <= 0.25: return 1
+        if ratio <= 0.5:  return 2
+        if ratio <= 0.75: return 3
+        return 4
+
+    # ── Month labels (above grid) ────────────────────────────────────────────
+    MONTH_NAMES = ["Jan","Feb","Mar","Apr","May","Jun",
+                   "Jul","Aug","Sep","Oct","Nov","Dec"]
+    last_month = -1
+    for col in range(COLS):
+        week_start = start_date + timedelta(days=col * 7)
+        if week_start.month != last_month:
+            mx = GRID_X + col * STEP
+            dwg.add(dwg.text(
+                MONTH_NAMES[week_start.month - 1],
+                insert=(mx, GRID_Y - 6),
+                fill=theme["text_color"],
+                font_size=9,
+                font_family=theme.get("font_family", "Arial"),
+                opacity=0.75
+            ))
+            last_month = week_start.month
+
+    # ── Day-of-week labels (left of grid) ────────────────────────────────────
+    for row, label in ((1, "Mon"), (3, "Wed"), (5, "Fri")):
+        dwg.add(dwg.text(
+            label,
+            insert=(GRID_X - 4, GRID_Y + row * STEP + CELL - 1),
+            fill=theme["text_color"],
+            font_size=8,
+            font_family=theme.get("font_family", "Arial"),
+            text_anchor="end",
+            opacity=0.65
+        ))
+
+    # ── Grid cells ───────────────────────────────────────────────────────────
+    for col in range(COLS):
+        for row in range(ROWS):
+            current = start_date + timedelta(days=col * 7 + row)
+            if current > today:
+                # future cell — draw faint outline only
+                dwg.add(dwg.rect(
+                    insert=(GRID_X + col * STEP, GRID_Y + row * STEP),
+                    size=(CELL, CELL),
+                    fill="none",
+                    stroke=theme["border_color"],
+                    stroke_width=0.5,
+                    rx=2, ry=2,
+                    opacity=0.3
+                ))
+                continue
+            count = date_counts.get(current, 0)
+            lvl   = _level(count)
+            dwg.add(dwg.rect(
+                insert=(GRID_X + col * STEP, GRID_Y + row * STEP),
+                size=(CELL, CELL),
+                fill=colors[lvl],
+                rx=2, ry=2
+            ))
+
+    # ── Legend ───────────────────────────────────────────────────────────────
+    legend_y  = height - 10
+    legend_x0 = width - PAD_RIGHT - (5 * (CELL + 3)) - 50
+
+    dwg.add(dwg.text("Less",
+        insert=(legend_x0, legend_y),
+        fill=theme["text_color"], font_size=9,
+        font_family=theme.get("font_family", "Arial"), opacity=0.6))
+
+    for i in range(5):
+        dwg.add(dwg.rect(
+            insert=(legend_x0 + 28 + i * (CELL + 3), legend_y - CELL + 1),
+            size=(CELL, CELL),
+            fill=colors[i], rx=2, ry=2
+        ))
+
+    dwg.add(dwg.text("More",
+        insert=(legend_x0 + 28 + 5 * (CELL + 3) + 3, legend_y),
+        fill=theme["text_color"], font_size=9,
+        font_family=theme.get("font_family", "Arial"), opacity=0.6))
+
+    return dwg.tostring()
+
+
 def draw_contrib_card(data, theme_name="Default", custom_colors=None, date_range=None, animations_enabled=True):
     """
     Generates the Contribution Graph Card SVG.

--- a/utils/github_api.py
+++ b/utils/github_api.py
@@ -111,12 +111,18 @@ def fetch_github_graphql(username, token=None):
     if not token:
         return None
 
+    from datetime import datetime, timedelta, timezone as _tz
+    _today = datetime.now(_tz.utc)
+    _from  = (_today - timedelta(days=365)).strftime("%Y-%m-%dT00:00:00Z")
+    _to    = _today.strftime("%Y-%m-%dT23:59:59Z")
+
     query = """
-    query ($login: String!) {
+    query ($login: String!, $from: DateTime!, $to: DateTime!) {
       user(login: $login) {
-        contributionsCollection {
+        contributionsCollection(from: $from, to: $to) {
           totalCommitContributions
           contributionCalendar {
+            totalContributions
             weeks {
               contributionDays {
                 date
@@ -136,7 +142,7 @@ def fetch_github_graphql(username, token=None):
     try:
         resp = requests.post(
             GITHUB_GRAPHQL_URL,
-            json={"query": query, "variables": {"login": username}},
+            json={"query": query, "variables": {"login": username, "from": _from, "to": _to}},
             headers=headers,
             timeout=10
         )
@@ -213,6 +219,10 @@ def parse_graphql_contributions(graphql_json):
                 contribution_weeks.append(week_days)
 
         total_commits = safe_get_nested_value(
+            graphql_json,
+            ["data", "user", "contributionsCollection", "contributionCalendar", "totalContributions"],
+            0
+        ) or safe_get_nested_value(
             graphql_json,
             ["data", "user", "contributionsCollection", "totalCommitContributions"],
             0


### PR DESCRIPTION
Issue #128 (Contribution under NSoC'26)

Added a brand new **📅 Yearly Calendar Heatmap** tab that was not present before.
Displays a full 365-day GitHub contribution heatmap similar to the one on
GitHub profiles, with extra customization options.
---
## ✨ What's New
### `generators/contrib_card.py`
- Added new `draw_calendar_heatmap_card()` function
- Full 365-day grid (53 weeks × 7 days) with proper computed layout
  so labels, grid, and legend never overlap (viewBox: 735×169)
- 4 granular intensity levels (none, low, medium, high, auto)
- Custom color palette support per intensity level
- Contribution count subtitle ("N contributions in the last year")
- Future cells render as faint outlines
- Light/dark background theme auto-detection for empty cell color

### `utils/github_api.py`
- Extended GraphQL query with `from`/`to` DateTime variables
  to fetch a true rolling 365-day window instead of current calendar year only
- Reads `totalContributions` (all contribution types) for accurate count

### `app.py`
- Added new **📅 Calendar Heatmap** tab (tab13)
- 5 intensity color pickers always visible, pre-filled with
  GitHub dark-mode defaults (#161b22 → #39d353) — change any to customise
- Renders live on every change, no button click needed
- Intensity level selector (auto/none/low/medium/high)
- Period selector (Last Year / Current Year / Custom Range)
- SVG download button + Markdown/HTML integration code

---

## 📸 Screenshots
<img width="1856" height="851" alt="image" src="https://github.com/user-attachments/assets/85764701-683a-47cc-a1ae-7e94f0b1f45d" />
<img width="1873" height="752" alt="image" src="https://github.com/user-attachments/assets/96290f1b-3a7f-41ac-bc9a-9c9d4f4efd96" />
<img width="1890" height="811" alt="image" src="https://github.com/user-attachments/assets/1afeec91-4548-46ea-9246-7d730ab194b4" />

---

## 🧪 Testing
- Tested with real GitHub data via GraphQL token
- Tested with mock data fallback
- Verified all 5 intensity levels
- Verified custom date range, current year, and last year options
- Verified color pickers update the heatmap live
