### PR TITLE
feat: add custom font override via ?font= query param (Resolves #174)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -9,6 +9,7 @@ from utils import github_api
 from utils.cache import cache_svg_response, get_cache_stats, clear_cache
 from utils.validators import (
     validate_date,
+    validate_font,
     validate_hex_color,
     validate_limit,
     validate_sort_by,
@@ -111,37 +112,44 @@ def get_token_from_header(request: Request) -> Optional[str]:
 def read_root():
     return {"message": "GitCanvas API is running"}
 
-def parse_colors(bg_color, title_color, text_color, border_color):
-    """Helper to construct custom color dict with validation."""
+def parse_custom_overrides(bg_color, title_color, text_color, border_color, font=None):
+    """
+    Helper to construct custom color + font override dict with validation.
+    font param is validated against allowlist to prevent SVG injection.
+    """
     colors = {}
-    
-    # Validate and add colors
+
     if bg_color:
         validated_bg = validate_hex_color(bg_color)
         if validated_bg:
             colors["bg_color"] = validated_bg
-            
+
     if title_color:
         validated_title = validate_hex_color(title_color)
         if validated_title:
             colors["title_color"] = validated_title
-            
+
     if text_color:
         validated_text = validate_hex_color(text_color)
         if validated_text:
             colors["text_color"] = validated_text
-            
+
     if border_color:
         validated_border = validate_hex_color(border_color)
         if validated_border:
             colors["border_color"] = validated_border
-    
+
+    if font:
+        validated_font = validate_font(font)
+        if validated_font:
+            colors["font_family"] = validated_font
+
     return colors if colors else None
 
 @app.get("/api/stats")
 async def get_stats(
     request: Request,
-    username: str, 
+    username: str,
     theme: str = "Default", 
     hide_stars: bool = False,
     hide_commits: bool = False,
@@ -151,7 +159,8 @@ async def get_stats(
     bg_color: Optional[str] = None,
     title_color: Optional[str] = None,
     text_color: Optional[str] = None,
-    border_color: Optional[str] = None
+    border_color: Optional[str] = None,
+    font: Optional[str] = None,
 ):
     # Validate inputs
     username = validate_username(username)
@@ -169,7 +178,7 @@ async def get_stats(
         "followers": not hide_followers
     }
     
-    custom_colors = parse_colors(bg_color, title_color, text_color, border_color)
+    custom_colors = parse_custom_overrides(bg_color, title_color, text_color, border_color, font)
     svg_content = generate_cached_svg(stats_card.draw_stats_card, data, theme, show_options=show_options, custom_colors=custom_colors, animations_enabled=animations_enabled)
     return svg_response(svg_content , request)
 
@@ -184,14 +193,15 @@ async def get_languages(
     bg_color: Optional[str] = None,
     title_color: Optional[str] = None,
     text_color: Optional[str] = None,
-    border_color: Optional[str] = None
+    border_color: Optional[str] = None,
+    font: Optional[str] = None,
 ):
     # Validate inputs
     username = validate_username(username)
     theme = validate_theme(theme)
     
     data = github_api.get_live_github_data(username) or github_api.get_mock_data(username)
-    custom_colors = parse_colors(bg_color, title_color, text_color, border_color)
+    custom_colors = parse_custom_overrides(bg_color, title_color, text_color, border_color, font)
     
     # Parse exclude parameter into list of languages
     excluded_languages_list = []
@@ -216,7 +226,8 @@ async def get_contributions(
     text_color: Optional[str] = None,
     border_color: Optional[str] = None,
     start_date: Optional[str] = None,
-    end_date: Optional[str] = None
+    end_date: Optional[str] = None,
+    font: Optional[str] = None,
 ):
     # Validate inputs
     username = validate_username(username)
@@ -225,7 +236,7 @@ async def get_contributions(
     end_date = validate_date(end_date)
     
     data = github_api.get_live_github_data(username) or github_api.get_mock_data(username)
-    custom_colors = parse_colors(bg_color, title_color, text_color, border_color)
+    custom_colors = parse_custom_overrides(bg_color, title_color, text_color, border_color, font)
     
     # Build date_range dict if dates are provided
     date_range = None
@@ -247,7 +258,8 @@ async def get_recent(
     bg_color: Optional[str] = None,
     title_color: Optional[str] = None,
     text_color: Optional[str] = None,
-    border_color: Optional[str] = None
+    border_color: Optional[str] = None,
+    font: Optional[str] = None,
 ):
     # Validate inputs
     username = validate_username(username)
@@ -257,7 +269,7 @@ async def get_recent(
     # This prevents token exposure in logs, browser history, and proxy logs
     token = get_token_from_header(request)
     
-    custom_colors = parse_colors(bg_color, title_color, text_color, border_color)
+    custom_colors = parse_custom_overrides(bg_color, title_color, text_color, border_color, font)
     svg_content = recent_activity_card.draw_recent_activity_card({'username': username}, theme, custom_colors=custom_colors, token=token)
     return svg_response(svg_content, request)
 
@@ -270,14 +282,15 @@ async def get_trophy(
     bg_color: Optional[str] = None,
     title_color: Optional[str] = None,
     text_color: Optional[str] = None,
-    border_color: Optional[str] = None
+    border_color: Optional[str] = None,
+    font: Optional[str] = None,
 ):
     # Validate inputs
     username = validate_username(username)
     theme = validate_theme(theme)
     
     data = github_api.get_live_github_data(username) or github_api.get_mock_data(username)
-    custom_colors = parse_colors(bg_color, title_color, text_color, border_color)
+    custom_colors = parse_custom_overrides(bg_color, title_color, text_color, border_color, font)
     svg_content = trophy_card.draw_trophy_card(data, theme, custom_colors=custom_colors)
     return svg_response(svg_content, request)
 
@@ -290,14 +303,15 @@ async def get_streak(
     bg_color: Optional[str] = None,
     title_color: Optional[str] = None,
     text_color: Optional[str] = None,
-    border_color: Optional[str] = None
+    border_color: Optional[str] = None,
+    font: Optional[str] = None,
 ):
     # Validate inputs
     username = validate_username(username)
     theme = validate_theme(theme)
     
     data = github_api.get_live_github_data(username) or github_api.get_mock_data(username)
-    custom_colors = parse_colors(bg_color, title_color, text_color, border_color)
+    custom_colors = parse_custom_overrides(bg_color, title_color, text_color, border_color, font)
     svg_content = streak_card.draw_streak_card(data, theme, custom_colors=custom_colors)
     return svg_response(svg_content, request)
 
@@ -312,7 +326,8 @@ async def get_repos(
     bg_color: Optional[str] = None,
     title_color: Optional[str] = None,
     text_color: Optional[str] = None,
-    border_color: Optional[str] = None
+    border_color: Optional[str] = None,
+    font: Optional[str] = None,
 ):
     # Validate inputs
     username = validate_username(username)
@@ -321,7 +336,7 @@ async def get_repos(
     limit = validate_limit(limit, min_val=1, max_val=10)
     
     data = github_api.get_live_github_data(username) or github_api.get_mock_data(username)
-    custom_colors = parse_colors(bg_color, title_color, text_color, border_color)
+    custom_colors = parse_custom_overrides(bg_color, title_color, text_color, border_color, font)
     svg_content = repo_card.draw_repo_card(data, theme, custom_colors=custom_colors, sort_by=sort_by, limit=limit)
     return svg_response(svg_content, request)
 
@@ -340,10 +355,11 @@ async def get_social_card(
     bg_color: Optional[str] = None,
     title_color: Optional[str] = None,
     text_color: Optional[str] = None,
-    border_color: Optional[str] = None
+    border_color: Optional[str] = None,
+    font: Optional[str] = None,
 ):
     theme = validate_theme(theme)
-    custom_colors = parse_colors(bg_color, title_color, text_color, border_color)
+    custom_colors = parse_custom_overrides(bg_color, title_color, text_color, border_color, font)
 
     if icon_color:
         icon_color = validate_hex_color(icon_color)

--- a/app.py
+++ b/app.py
@@ -106,7 +106,22 @@ with st.sidebar:
     # Combine with custom themes at the end
     theme_options = predefined_themes + custom_theme_names
     
-    # ── Theme Search & Filter (Issue #163) ───────────────────────────────────
+    # ── Custom Font Override (Issue #174) ────────────────────────────────────
+    st.markdown("**Font Override**")
+    FONT_OPTIONS = [
+        "Theme Default",
+        "Inter", "Roboto", "Poppins", "Lato", "Montserrat",
+        "Ubuntu", "Nunito", "Merriweather", "Playfair",
+        "Fira Code", "JetBrains Mono", "Space Mono"
+    ]
+    selected_font = st.selectbox(
+        "Card Font",
+        FONT_OPTIONS,
+        help="Override the theme's default font for all generated cards."
+    )
+    # None means use theme default — only pass if user picked something
+    font_override = None if selected_font == "Theme Default" else selected_font
+    # ── End font override ─────────────────────────────────────────────────────
     st.markdown("**Filter Themes**")
 
     # Search bar
@@ -316,10 +331,17 @@ data.setdefault("top_languages", [])
 data.setdefault("contributions", [])
 
 
+
 # Apply custom colors to current theme for python logic
 current_theme_opts = all_themes.get(selected_theme, all_themes["Default"]).copy()
 if custom_colors:
     current_theme_opts.update(custom_colors)
+
+# Add font override to custom_colors if set
+if font_override and custom_colors:
+    custom_colors["font_family"] = font_override
+elif font_override:
+    custom_colors = {"font_family": font_override}
 
 
 # --- Layout: Tabs ---
@@ -334,7 +356,7 @@ def show_code_area(code_content, label="Markdown Code"):
     st.markdown(f"**{label}** (Copy below)")
     st.text_area(label, value=code_content, height=100, label_visibility="collapsed")
 
-def render_tab(svg_bytes, endpoint, username, selected_theme, custom_colors, hide_params=None, code_template=None, excluded_languages=None, output_format="Markdown"):
+def render_tab(svg_bytes, endpoint, username, selected_theme, custom_colors, hide_params=None, code_template=None, excluded_languages=None, output_format="Markdown", font_override=None):
     col1, col2 = st.columns([1.5, 1])
     with col1:
         # Render SVG
@@ -501,7 +523,7 @@ with tab1:
             custom_colors,
             animations_enabled,
         )
-    render_tab(svg_bytes, "stats", username, selected_theme, custom_colors, hide_params=show_ops, code_template=f"[![{username}'s Stats]({{url}})](https://github.com/{{username}})", output_format=output_format)
+    render_tab(svg_bytes, "stats", username, selected_theme, custom_colors, hide_params=show_ops, code_template=f"[![{username}'s Stats]({{url}})](https://github.com/{{username}})", output_format=output_format, font_override=font_override)
     
     # Prepare the SVG string from your generator
     # Use real contribution data already loaded (last 30 days) - no extra API call needed
@@ -575,7 +597,7 @@ with tab2:
     
     # Generate card with exclusions - Pass selected_theme string
     svg_bytes = lang_card.draw_lang_card(data, selected_theme, custom_colors, excluded_languages=excluded_languages)
-    render_tab(svg_bytes, "languages", username, selected_theme, custom_colors, code_template="![Top Langs]({url})", excluded_languages=excluded_languages_str, output_format=output_format)
+    render_tab(svg_bytes, "languages", username, selected_theme, custom_colors, code_template="![Top Langs]({url})", excluded_languages=excluded_languages_str, output_format=output_format, font_override=font_override)
 
 with tab3:
     st.subheader("Top Repositories")
@@ -597,7 +619,7 @@ with tab3:
     
     compact_repo = st.checkbox("📐 Compact Layout", value=False, help="Slim 300px card — fit multiple cards in one README row", key="compact_repo")
     svg_bytes = repo_card.draw_repo_card(filtered_data, selected_theme, custom_colors, sort_by=sort_by, limit=repo_limit, compact=compact_repo)
-    render_tab(svg_bytes, "repos", username, selected_theme, custom_colors, code_template="![Top Repos]({url})", output_format=output_format)
+    render_tab(svg_bytes, "repos", username, selected_theme, custom_colors, code_template="![Top Repos]({url})", output_format=output_format, font_override=font_override)
 
 with tab4:
     st.subheader("Contribution Graph")
@@ -646,14 +668,14 @@ with tab4:
 
     # Pass selected_theme string and date_range
     svg_bytes = contrib_card.draw_contrib_card(data, selected_theme, custom_colors, date_range=date_range, animations_enabled=animations_enabled)
-    render_tab(svg_bytes, "contributions", username, selected_theme, custom_colors, code_template="![Contributions]({url})", output_format=output_format)
+    render_tab(svg_bytes, "contributions", username, selected_theme, custom_colors, code_template="![Contributions]({url})", output_format=output_format, font_override=font_override)
 
 with tab5:
     st.subheader("GitHub Streak")
     st.caption("🔥 Track your contribution streaks! Shows current consecutive days and your all-time longest streak.")
     
     svg_bytes = streak_card.draw_streak_card(data, selected_theme, custom_colors)
-    render_tab(svg_bytes, "streak", username, selected_theme, custom_colors, code_template="![GitHub Streak]({url})", output_format=output_format)
+    render_tab(svg_bytes, "streak", username, selected_theme, custom_colors, code_template="![GitHub Streak]({url})", output_format=output_format, font_override=font_override)
 
 with tab6:
     st.subheader("🔗 Social Links")
@@ -865,7 +887,7 @@ with tab11:
         trophy_data["created_at"] = "2010-01-01T00:00:00Z"
     
     svg_bytes = trophy_card.draw_trophy_card(trophy_data, selected_theme, custom_colors)
-    render_tab(svg_bytes, "trophy", username, selected_theme, custom_colors, code_template="![GitHub Trophy]({url})", output_format=output_format)
+    render_tab(svg_bytes, "trophy", username, selected_theme, custom_colors, code_template="![GitHub Trophy]({url})", output_format=output_format, font_override=font_override)
 
     # ── NEW: Theme Gallery Tab (Issue #162) ──────────────────────────────────
 with tab12:

--- a/utils/validators.py
+++ b/utils/validators.py
@@ -197,3 +197,41 @@ def validate_date(date_str: Optional[str]) -> Optional[str]:
         )
     
     return date_str
+
+
+# Allowed safe web-safe + Google Fonts 
+ALLOWED_FONTS = {
+    "inter", "roboto", "poppins", "lato", "montserrat", "opensans",
+    "raleway", "nunito", "ubuntu", "sourcesanspro", "merriweather",
+    "playfair", "firacode", "jetbrainsmono", "spacemono", "inconsolata",
+    "segoeui", "arial", "verdana", "georgia", "couriernew"
+}
+
+def validate_font(font: Optional[str]) -> Optional[str]:
+    """
+    Validates and sanitizes a font name query param.
+    Only allows known safe font names to prevent SVG injection.
+    Strips spaces, lowercases for comparison, returns original casing.
+
+    Args:
+        font: raw font string from query param e.g. "Inter" or "Fira Code"
+
+    Returns:
+        Sanitized font string or None if invalid/not provided
+    """
+    if not font:
+        return None
+
+    # Strip dangerous characters — only allow letters, digits, spaces
+    import re
+    font = re.sub(r"[^a-zA-Z0-9 ]", "", font).strip()
+
+    if not font:
+        return None
+
+    # Check against allowlist (case-insensitive, spaces stripped)
+    normalized = font.replace(" ", "").lower()
+    if normalized not in ALLOWED_FONTS:
+        return None  # Silently fall back to theme default
+
+    return font


### PR DESCRIPTION
- Contributing on behalf of NSoC'26

## Changes Made

- Added `ALLOWED_FONTS` allowlist + `validate_font()` in `utils/validators.py`
- Renamed `parse_colors()` → `parse_custom_overrides()` in `api/main.py`
- All 8 API endpoints now accept `?font=` query param
- Font validated against allowlist to prevent SVG injection
- Streamlit sidebar (`app.py`) exposes font picker and passes `font_override` to all `render_tab()` calls

## Testing
- `GET /api/stats?username=torvalds&font=Inter` → SVG uses Inter font
- `GET /api/stats?username=torvalds&font=<script>evil</script>` → rejected silently

Resolves #174

@devanshi14malhotra please review 
