### PR TITLE
Fix: Restrict CORS Origins (Closes #61)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 GITHUB_TOKEN=your_github_token_here
 OPENAI_API_KEY=your_openai_api_key_here
 GEMINI_API_KEY=your_gemini_api_key_here
+
+# CORS: comma-separated list of allowed origins, or '*' to allow all (default, not recommended for production)
+# Example: ALLOWED_ORIGINS=https://gitcanvas-dm.streamlit.app,https://yourdomain.com
+ALLOWED_ORIGINS=*

--- a/api/main.py
+++ b/api/main.py
@@ -25,12 +25,13 @@ async def lifespan(_app: FastAPI):
 app = FastAPI(lifespan=lifespan)
 
 # Configure CORS middleware
+_settings = get_settings()
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # Configure appropriately for production
-    allow_methods=["GET", "DELETE"],  # Allow GET for API endpoints and DELETE for cache management
+    allow_origins=_settings.allowed_origins_list(),
+    allow_methods=["GET", "DELETE"],
     allow_headers=["*"],
-    allow_credentials=False,  # Set to True if you need to support credentials
+    allow_credentials=False,
 )
 
 # Implements HTTP conditional requests for CDN-safe SVG caching

--- a/config/settings.py
+++ b/config/settings.py
@@ -36,6 +36,18 @@ class GitCanvasSettings(BaseSettings):
     redis_enabled: bool = Field(default=False, description="Enable Redis caching for distributed deployments")
     redis_key_prefix: str = Field(default="gitcanvas:", description="Redis key prefix used to isolate this app's keys")
 
+    # CORS configuration
+    allowed_origins: str = Field(
+        default="*",
+        description="Comma-separated list of allowed CORS origins, or '*' to allow all (not recommended for production)",
+    )
+
+    def allowed_origins_list(self) -> list[str]:
+        """Return parsed list of allowed origins."""
+        if self.allowed_origins.strip() == "*":
+            return ["*"]
+        return [o.strip() for o in self.allowed_origins.split(",") if o.strip()]
+
     # Cache-clear endpoint protection
     cache_clear_enabled: bool = Field(
         default=False,


### PR DESCRIPTION
Contributing under NSoC'26
closes #61 

`api/main.py` had `allow_origins=["*"]` in the FastAPI `CORSMiddleware` 
configuration, accepting requests from any origin — a potential 
cross-origin security risk.

> Note: Issue #61 references `backend/server.js`, but this project uses 
> FastAPI (`api/main.py`) — the same security concern applies.

### Changes
- **`api/main.py`** — replaced hardcoded `["*"]` with `settings.allowed_origins_list()`
- **`config/settings.py`** — added `ALLOWED_ORIGINS` env var field with a helper to parse comma-separated origins
- **`.env.example`** — documented the new `ALLOWED_ORIGINS` variable

### How it works
- Default is `*` (no breaking change for local dev)
- In production, set in `.env`:
ALLOWED_ORIGINS=https://gitcanvas-dm.streamlit.app,https://yourdomain.com

### Testing
- Unset `ALLOWED_ORIGINS` → behaves exactly as before (`*`)
- Set `ALLOWED_ORIGINS=https://example.com` → only that origin is allowed
