### PR TITLE
feat: persist custom themes via pluggable storage backend (Resolves #170)

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,6 +19,7 @@ except ImportError:
         return None
 from utils.cache import clear_cache as clear_ttl_cache
 from themes.styles import THEMES, get_all_themes, CUSTOM_THEMES
+from utils.theme_storage import get_storage_backend
 from utils.error_card import draw_error_card
 from generators.visual_elements import (
     emoji_element,
@@ -37,6 +38,14 @@ get_settings.cache_clear()
 _settings = get_settings()
 
 st.set_page_config(page_title="GitCanvas Builder", page_icon="🛠️", layout="wide")
+
+# Load persisted custom themes from storage backend on every rerun
+CUSTOM_THEMES.clear()
+_storage = get_storage_backend()
+for _name in _storage.list_themes():
+    _data = _storage.load_theme(_name)
+    if _data:
+        CUSTOM_THEMES[_name] = _data
 
 # Custom CSS for bigger code boxes and cleaner UI
 st.markdown("""
@@ -122,8 +131,7 @@ with st.sidebar:
     
     # Get all themes including custom ones
     all_themes = get_all_themes()
-    
-    # Separate predefined and custom themes for better organization
+
     predefined_themes = [k for k in all_themes.keys() if k not in CUSTOM_THEMES]
     custom_theme_names = list(CUSTOM_THEMES.keys())
     
@@ -251,9 +259,12 @@ with st.sidebar:
         
         if st.button("💾 Save Theme", use_container_width=True):
             if theme_name:
-                from themes.styles import save_custom_theme
-                filename = save_custom_theme(theme_name, st.session_state.custom_theme_colors)
-                st.success(f"Theme '{theme_name}' saved! Refresh to see it in the theme list.")
+                from utils.theme_storage import get_storage_backend
+                storage = get_storage_backend()
+                storage.save_theme(theme_name, st.session_state.custom_theme_colors)
+                st.success(f"Theme '{theme_name}' saved!")
+                st.cache_data.clear()
+                st.rerun()
             else:
                 st.error("Please enter a theme name")
 
@@ -473,8 +484,21 @@ def render_tab(svg_bytes, endpoint, username, selected_theme, custom_colors, hid
                 if not value:
                     params.append(f"hide_{key}=true")
 
+        # Handle theme: for custom themes, extract colors and send as params instead of theme name
+        # This ensures the API receives actual color values for unknown custom themes
         if selected_theme != "Default":
-            params.append(f"theme={selected_theme}")
+            if selected_theme in CUSTOM_THEMES:
+                # Custom theme: send individual color params instead of theme name
+                custom_theme_data = CUSTOM_THEMES[selected_theme]
+                for color_key in ["bg_color", "border_color", "title_color", "text_color", "icon_color"]:
+                    if color_key in custom_theme_data:
+                        color_val = custom_theme_data[color_key]
+                        params.append(f"{color_key}={color_val.replace('#', '')}")
+            else:
+                # Predefined theme: send theme name
+                params.append(f"theme={selected_theme}")
+        
+        # Add custom color overrides from the "Customize Colors" section
         for k, v in custom_colors.items():
             params.append(f"{k}={v.replace('#', '')}")
 

--- a/generators/stats_card.py
+++ b/generators/stats_card.py
@@ -366,7 +366,7 @@ def draw_stats_card(data, theme_name="Default", show_options=None, custom_colors
     # ── End Compact Layout ────────────────────────────────────────────────
     
     # Title
-    font_family = theme["font_family"]
+    font_family = theme.get("font_family", "Segoe UI, Ubuntu, Sans-Serif")
     title_params = {
         "insert": (20, 35),
         "fill": theme["title_color"],

--- a/utils/theme_storage.py
+++ b/utils/theme_storage.py
@@ -1,0 +1,227 @@
+from abc import ABC, abstractmethod
+from typing import Optional
+import json
+import os
+import re
+import sqlite3
+
+
+# ── Abstract Base ──────────────────────────────────────────────────────────────
+
+class ThemeStorage(ABC):
+    """Abstract base class for theme storage backends."""
+
+    @abstractmethod
+    def save_theme(self, name: str, data: dict) -> bool:
+        pass
+
+    @abstractmethod
+    def load_theme(self, name: str) -> Optional[dict]:
+        pass
+
+    @abstractmethod
+    def list_themes(self) -> list[str]:
+        pass
+
+    @abstractmethod
+    def delete_theme(self, name: str) -> bool:
+        pass
+
+
+# ── Local File Backend ─────────────────────────────────────────────────────────
+
+class LocalFileStorage(ThemeStorage):
+    """Local JSON file backend — dev fallback."""
+
+    def __init__(self, themes_dir: str = "themes/custom_db"):
+        self.themes_dir = themes_dir
+        os.makedirs(themes_dir, exist_ok=True)
+
+    def _path(self, name: str) -> str:
+        safe = "".join(c for c in name if c.isalnum() or c in ("-", "_"))
+        return os.path.join(self.themes_dir, f"{safe}.json")
+
+    def save_theme(self, name: str, data: dict) -> bool:
+        try:
+            with open(self._path(name), "w") as f:
+                json.dump(data, f, indent=2)
+            return True
+        except Exception:
+            return False
+
+    def load_theme(self, name: str) -> Optional[dict]:
+        path = self._path(name)
+        if not os.path.exists(path):
+            return None
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except Exception:
+            return None
+
+    def list_themes(self) -> list[str]:
+        if not os.path.exists(self.themes_dir):
+            return []
+        return [f.replace(".json", "") for f in os.listdir(self.themes_dir) if f.endswith(".json")]
+
+    def delete_theme(self, name: str) -> bool:
+        path = self._path(name)
+        if not os.path.exists(path):
+            return False
+        try:
+            os.remove(path)
+            return True
+        except Exception:
+            return False
+
+
+# ── SQLite Backend ─────────────────────────────────────────────────────────────
+
+class SQLiteThemeStorage(ThemeStorage):
+    """SQLite backend — works locally and on Streamlit Cloud (/tmp)."""
+
+    def __init__(self, db_path: str = None):
+            if db_path is None:
+                import tempfile
+                db_path = os.path.join(tempfile.gettempdir(), "gitcanvas_themes.db")
+            self.db_path = db_path
+            self._init_db()
+
+    def _connect(self):
+        return sqlite3.connect(self.db_path)
+
+    def _init_db(self):
+        with self._connect() as conn:
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS themes (
+                    name TEXT PRIMARY KEY,
+                    data TEXT NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+            conn.commit()
+
+    def save_theme(self, name: str, data: dict) -> bool:
+        try:
+            with self._connect() as conn:
+                conn.execute("""
+                    INSERT INTO themes (name, data) VALUES (?, ?)
+                    ON CONFLICT(name) DO UPDATE SET data = excluded.data
+                """, (name, json.dumps(data)))
+                conn.commit()
+            return True
+        except Exception:
+            return False
+
+    def load_theme(self, name: str) -> Optional[dict]:
+        try:
+            with self._connect() as conn:
+                row = conn.execute("SELECT data FROM themes WHERE name = ?", (name,)).fetchone()
+            return json.loads(row[0]) if row else None
+        except Exception:
+            return None
+
+    def list_themes(self) -> list[str]:
+        try:
+            with self._connect() as conn:
+                rows = conn.execute("SELECT name FROM themes ORDER BY name").fetchall()
+            return [row[0] for row in rows]
+        except Exception:
+            return []
+
+    def delete_theme(self, name: str) -> bool:
+        try:
+            with self._connect() as conn:
+                cursor = conn.execute("DELETE FROM themes WHERE name = ?", (name,))
+                conn.commit()
+            return cursor.rowcount > 0
+        except Exception:
+            return False
+
+
+# ── Firebase Backend ───────────────────────────────────────────────────────────
+
+class FirebaseThemeStorage(ThemeStorage):
+    """
+    Firebase Firestore backend — for production cloud persistence.
+    Requires FIREBASE_CREDENTIALS env var (JSON string of service account).
+    Falls back gracefully if credentials not set.
+    """
+
+    def __init__(self):
+        self._db = None
+        self._collection = "custom_themes"
+        self._init_firebase()
+
+    def _init_firebase(self):
+        try:
+            import firebase_admin
+            from firebase_admin import credentials, firestore
+
+            creds_json = os.environ.get("FIREBASE_CREDENTIALS")
+            if not creds_json:
+                return
+
+            if not firebase_admin._apps:
+                cred = credentials.Certificate(json.loads(creds_json))
+                firebase_admin.initialize_app(cred)
+
+            self._db = firestore.client()
+        except Exception:
+            self._db = None  # Graceful fallback
+
+    def _is_available(self) -> bool:
+        return self._db is not None
+
+    def save_theme(self, name: str, data: dict) -> bool:
+        if not self._is_available():
+            return False
+        try:
+            self._db.collection(self._collection).document(name).set(data)
+            return True
+        except Exception:
+            return False
+
+    def load_theme(self, name: str) -> Optional[dict]:
+        if not self._is_available():
+            return None
+        try:
+            doc = self._db.collection(self._collection).document(name).get()
+            return doc.to_dict() if doc.exists else None
+        except Exception:
+            return None
+
+    def list_themes(self) -> list[str]:
+        if not self._is_available():
+            return []
+        try:
+            docs = self._db.collection(self._collection).stream()
+            return [doc.id for doc in docs]
+        except Exception:
+            return []
+
+    def delete_theme(self, name: str) -> bool:
+        if not self._is_available():
+            return False
+        try:
+            self._db.collection(self._collection).document(name).delete()
+            return True
+        except Exception:
+            return False
+
+
+# ── Auto-select Backend ────────────────────────────────────────────────────────
+
+def get_storage_backend() -> ThemeStorage:
+    """
+    Auto-selects storage backend based on environment:
+    - FIREBASE_CREDENTIALS set → FirebaseThemeStorage
+    - Otherwise              → SQLiteThemeStorage (default for Streamlit Cloud)
+    """
+    if os.environ.get("FIREBASE_CREDENTIALS"):
+        backend = FirebaseThemeStorage()
+        if backend._is_available():
+            return backend
+
+    # Use SQLite by default — survives Streamlit Cloud restarts better than local files
+    return SQLiteThemeStorage()


### PR DESCRIPTION
- Contributing on behalf of NSoC'26

## Problem
Custom themes were written to local JSON files — wiped on every 
Streamlit Cloud/Heroku restart.

## Solution
- Added `utils/theme_storage.py` with pluggable `ThemeStorage` interface
- `LocalFileStorage` — existing JSON file logic (dev fallback)
- `SQLiteThemeStorage` — survives Streamlit Cloud restarts via /tmp
- `FirebaseThemeStorage` — full cloud persistence via FIREBASE_CREDENTIALS env var
- `get_storage_backend()` — auto-selects backend based on environment
- Storage loading moved to top-level so themes load on every rerun
- Custom theme colors properly passed to API via URL params


Resolves #170

@devanshi14malhotra please review 