### PR TITLE
fix: add missing tags to theme JSON files (Resolves #211)

### DIFF
--- a/themes/json/cricket.json
+++ b/themes/json/cricket.json
@@ -1,10 +1,15 @@
 {
-  "bg_color": "#1a5f1a",
-  "title_color": "#ffffff",
-  "text_color": "#ffffff",
-  "border_color": "#ffd700",
-  "icon_color": "#ff6b35",
-  "title_font_size": "18px",
-  "text_font_size": "14px",
-  "font_family": "monospace"
+    "bg_color": "#1a5f1a",
+    "title_color": "#ffffff",
+    "text_color": "#ffffff",
+    "border_color": "#ffd700",
+    "icon_color": "#ff6b35",
+    "title_font_size": "18px",
+    "text_font_size": "14px",
+    "font_family": "monospace",
+    "tags": [
+        "light",
+        "colorful",
+        "minimal"
+    ]
 }

--- a/themes/json/cyberpunk.json
+++ b/themes/json/cyberpunk.json
@@ -1,10 +1,16 @@
 {
-  "bg_color": "#0a0a0f",
-  "title_color": "#00ff41",
-  "text_color": "#00ffff",
-  "border_color": "#ff00ff",
-  "icon_color": "#ff0080",
-  "title_font_size": "18px",
-  "text_font_size": "14px",
-  "font_family": "monospace"
+    "bg_color": "#0a0a0f",
+    "title_color": "#00ff41",
+    "text_color": "#00ffff",
+    "border_color": "#ff00ff",
+    "icon_color": "#ff0080",
+    "title_font_size": "18px",
+    "text_font_size": "14px",
+    "font_family": "monospace",
+    "tags": [
+        "dark",
+        "neon",
+        "colorful",
+        "tech"
+    ]
 }

--- a/themes/json/default.json
+++ b/themes/json/default.json
@@ -6,5 +6,10 @@
     "icon_color": "#8b949e",
     "font_family": "Segoe UI, Ubuntu, Sans-Serif",
     "title_font_size": 20,
-    "text_font_size": 14
+    "text_font_size": 14,
+    "tags": [
+        "light",
+        "minimal",
+        "clean"
+    ]
 }

--- a/themes/json/dracula.json
+++ b/themes/json/dracula.json
@@ -6,5 +6,10 @@
     "icon_color": "#50fa7b",
     "font_family": "Segoe UI, Ubuntu, Sans-Serif",
     "title_font_size": 20,
-    "text_font_size": 14
+    "text_font_size": 14,
+    "tags": [
+        "dark",
+        "purple",
+        "minimal"
+    ]
 }

--- a/themes/json/fire.json
+++ b/themes/json/fire.json
@@ -6,5 +6,11 @@
     "icon_color": "#ff6a00",
     "font_family": "Segoe UI, Ubuntu, Sans-Serif",
     "title_font_size": 20,
-    "text_font_size": 14
+    "text_font_size": 14,
+    "tags": [
+        "dark",
+        "red",
+        "colorful",
+        "neon"
+    ]
 }

--- a/themes/json/gaming.json
+++ b/themes/json/gaming.json
@@ -7,5 +7,11 @@
     "font_family": "'Courier New', Courier, monospace",
     "title_font_size": 18,
     "text_font_size": 14,
-    "is_pixel": true
+    "is_pixel": true,
+    "tags": [
+        "dark",
+        "neon",
+        "gaming",
+        "colorful"
+    ]
 }

--- a/themes/json/glass.json
+++ b/themes/json/glass.json
@@ -6,5 +6,10 @@
     "icon_color": "#7dd3fc",
     "font_family": "'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
     "title_font_size": 22,
-    "text_font_size": 14
-  }
+    "text_font_size": 14,
+    "tags": [
+        "light",
+        "minimal",
+        "clean"
+    ]
+}

--- a/themes/json/marvel.json
+++ b/themes/json/marvel.json
@@ -6,5 +6,10 @@
     "icon_color": "#e23636",
     "font_family": "Impact, sans-serif",
     "title_font_size": 22,
-    "text_font_size": 14
+    "text_font_size": 14,
+    "tags": [
+        "dark",
+        "red",
+        "colorful"
+    ]
 }

--- a/themes/json/matrix.json
+++ b/themes/json/matrix.json
@@ -1,10 +1,16 @@
 {
-  "bg_color": "#000000",
-  "border_color": "#00ff00",
-  "title_color": "#00ff00",
-  "text_color": "#00ff88",
-  "icon_color": "#00ff41",
-  "font_family": "Courier New, monospace",
-  "title_font_size": 18,
-  "text_font_size": 14
+    "bg_color": "#000000",
+    "border_color": "#00ff00",
+    "title_color": "#00ff00",
+    "text_color": "#00ff88",
+    "icon_color": "#00ff41",
+    "font_family": "Courier New, monospace",
+    "title_font_size": 18,
+    "text_font_size": 14,
+    "tags": [
+        "dark",
+        "green",
+        "tech",
+        "neon"
+    ]
 }

--- a/themes/json/ocean.json
+++ b/themes/json/ocean.json
@@ -6,5 +6,10 @@
     "icon_color": "#2288cc",
     "font_family": "Segoe UI, Ubuntu, Sans-Serif",
     "title_font_size": 20,
-    "text_font_size": 14
+    "text_font_size": 14,
+    "tags": [
+        "dark",
+        "blue",
+        "minimal"
+    ]
 }

--- a/themes/json/pacman.json
+++ b/themes/json/pacman.json
@@ -1,10 +1,16 @@
 {
-  "bg_color": "#000000",
-  "title_color": "#ffff00",
-  "text_color": "#ffffff",
-  "border_color": "#1919a6",
-  "icon_color": "#ff8c00",
-  "title_font_size": "18px",
-  "text_font_size": "14px",
-  "font_family": "monospace"
+    "bg_color": "#000000",
+    "title_color": "#ffff00",
+    "text_color": "#ffffff",
+    "border_color": "#1919a6",
+    "icon_color": "#ff8c00",
+    "title_font_size": "18px",
+    "text_font_size": "14px",
+    "font_family": "monospace",
+    "tags": [
+        "dark",
+        "retro",
+        "gaming",
+        "colorful"
+    ]
 }

--- a/themes/json/retro.json
+++ b/themes/json/retro.json
@@ -6,6 +6,10 @@
     "icon_color": "#a08060",
     "font_family": "'Courier New', Courier, monospace",
     "title_font_size": 18,
-    "text_font_size": 14
+    "text_font_size": 14,
+    "tags": [
+        "light",
+        "retro",
+        "colorful"
+    ]
 }
-

--- a/themes/json/space.json
+++ b/themes/json/space.json
@@ -6,5 +6,11 @@
     "icon_color": "#39d353",
     "font_family": "Verdana, Geneva, sans-serif",
     "title_font_size": 18,
-    "text_font_size": 14
+    "text_font_size": 14,
+    "tags": [
+        "dark",
+        "blue",
+        "minimal",
+        "tech"
+    ]
 }

--- a/themes/json/squid_game.json
+++ b/themes/json/squid_game.json
@@ -6,5 +6,10 @@
     "icon_color": "#ff6aa9",
     "font_family": "Segoe UI, Ubuntu, Sans-Serif",
     "title_font_size": 20,
-    "text_font_size": 14
+    "text_font_size": 14,
+    "tags": [
+        "dark",
+        "red",
+        "minimal"
+    ]
 }

--- a/themes/json/stranger_things.json
+++ b/themes/json/stranger_things.json
@@ -1,10 +1,15 @@
 {
-  "bg_color": "#0a0a0a",
-  "title_color": "#ff0000",
-  "text_color": "#ffffff",
-  "border_color": "#8b0000",
-  "icon_color": "#dc143c",
-  "title_font_size": "18px",
-  "text_font_size": "14px",
-  "font_family": "monospace"
+    "bg_color": "#0a0a0a",
+    "title_color": "#ff0000",
+    "text_color": "#ffffff",
+    "border_color": "#8b0000",
+    "icon_color": "#dc143c",
+    "title_font_size": "18px",
+    "text_font_size": "14px",
+    "font_family": "monospace",
+    "tags": [
+        "dark",
+        "retro",
+        "neon"
+    ]
 }

--- a/themes/json/wednesday.json
+++ b/themes/json/wednesday.json
@@ -6,5 +6,10 @@
     "icon_color": "#6b6b7a",
     "font_family": "Segoe UI, Ubuntu, Sans-Serif",
     "title_font_size": 20,
-    "text_font_size": 14
+    "text_font_size": 14,
+    "tags": [
+        "dark",
+        "minimal",
+        "clean"
+    ]
 }


### PR DESCRIPTION
- Contributing on behalf of NSoC'26

## Bug
Theme search filters and tag pills only showed 'Neural' theme because 
all other themes had no `tags` field in their JSON files.

## Root Cause
Only `neural.json` had a `"tags"` array. All other 16 theme JSON 
files were missing the `tags` field entirely.

## Fix
Added appropriate `tags` arrays to all 16 theme JSON files:
- Dark themes: dark, minimal, neon, tech, colorful, etc.
- Light themes: light, minimal, clean, colorful
- Special: gaming, retro, purple, blue, green, red

## Testing
- Filter by `dark` → shows all dark themes 
- Filter by `neon` → shows Gaming, Cyberpunk, Matrix, Fire
- Search "retro" → shows Pacman, Retro, Stranger Things 

Resolves #211
Parent: #163

@devanshi14malhotra please review 