### PR TITLE
fix: Bare except Exception Blocks Swallowing All Errors

### DIFF
--- a/ai/ai_roast_service.py
+++ b/ai/ai_roast_service.py
@@ -10,7 +10,7 @@ from config.settings import get_settings
 try:
     import google.generativeai as genai  # type: ignore
     _HAS_GENAI = True
-except Exception:
+except ImportError:
     genai = None
     _HAS_GENAI = False
 from openai import OpenAI

--- a/ai/generative.py
+++ b/ai/generative.py
@@ -11,7 +11,7 @@ import logging
 try:
     import google.generativeai as genai
     _HAS_GENAI = True
-except Exception:
+except ImportError:
     genai = None
     _HAS_GENAI = False
 

--- a/generators/contrib_card.py
+++ b/generators/contrib_card.py
@@ -53,7 +53,7 @@ def _latest_contribution_date(contributions):
             continue
         try:
             parsed = date.fromisoformat(item_date)
-        except Exception:
+        except (TypeError, ValueError):
             continue
         if not max_date or parsed > max_date:
             max_date = parsed
@@ -132,7 +132,7 @@ def _weeks_to_cells(weeks, cols, rows, max_date):
             if item_date:
                 try:
                     parsed = date.fromisoformat(item_date)
-                except Exception:
+                except (TypeError, ValueError):
                     parsed = None
             is_future = bool(max_date and parsed and parsed > max_date)
             cells.append({
@@ -153,7 +153,7 @@ def _add_timeline_labels(dwg, weeks, cols, rows, start_x, start_y, box_size, gap
         if day and day.get("date"):
             try:
                 day_date = date.fromisoformat(day["date"])
-            except Exception:
+            except (TypeError, ValueError):
                 day_date = None
 
         if not day_date:

--- a/generators/contrib_card_MERGED.py
+++ b/generators/contrib_card_MERGED.py
@@ -49,7 +49,7 @@ def _latest_contribution_date(contributions):
             continue
         try:
             parsed = date.fromisoformat(item_date)
-        except Exception:
+        except (TypeError, ValueError):
             continue
         if not max_date or parsed > max_date:
             max_date = parsed
@@ -71,7 +71,7 @@ def _weeks_from_dates(contributions, cols, rows):
             continue
         try:
             parsed = date.fromisoformat(item_date)
-        except Exception:
+        except (TypeError, ValueError):
             continue
         date_counts[parsed] = item.get("count", 0)
 
@@ -126,7 +126,7 @@ def _weeks_to_cells(weeks, cols, rows, max_date):
             if item_date:
                 try:
                     parsed = date.fromisoformat(item_date)
-                except Exception:
+                except (TypeError, ValueError):
                     parsed = None
             is_future = bool(max_date and parsed and parsed > max_date)
             cells.append({
@@ -147,7 +147,7 @@ def _add_timeline_labels(dwg, weeks, cols, rows, start_x, start_y, box_size, gap
         if day and day.get("date"):
             try:
                 day_date = date.fromisoformat(day["date"])
-            except Exception:
+            except (TypeError, ValueError):
                 day_date = None
 
         if not day_date:

--- a/generators/trophy_card.py
+++ b/generators/trophy_card.py
@@ -23,7 +23,7 @@ def draw_trophy_card(data, theme_name="Default", custom_colors=None):
             years_contributing = (datetime.now() - created_date).days // 365
             if years_contributing < 1:
                 years_contributing = 1
-        except Exception:
+        except (TypeError, ValueError):
             years_contributing = 1
     
     # Determine repository quality tier

--- a/test_exception_handling_unit.py
+++ b/test_exception_handling_unit.py
@@ -1,0 +1,61 @@
+import unittest
+from datetime import date, timedelta
+from unittest.mock import patch
+
+from generators.contrib_card import _latest_contribution_date
+from utils.api_validators import safe_get_nested_value
+from utils.github_api import fetch_sparkline_data
+
+
+class ExplodingDict(dict):
+    def __getitem__(self, key):
+        raise RuntimeError("boom")
+
+
+class FakeResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class ExceptionHandlingTests(unittest.TestCase):
+    def test_latest_contribution_date_skips_invalid_dates(self):
+        valid_date = date.today() - timedelta(days=2)
+        newer_valid_date = date.today() - timedelta(days=1)
+        contributions = [
+            {"date": "not-a-date", "count": 1},
+            {"date": valid_date.isoformat(), "count": 2},
+            {"date": None, "count": 3},
+            {"date": newer_valid_date.isoformat(), "count": 4},
+        ]
+
+        self.assertEqual(_latest_contribution_date(contributions), newer_valid_date)
+
+    def test_safe_get_nested_value_does_not_swallow_runtime_errors(self):
+        with self.assertRaises(RuntimeError):
+            safe_get_nested_value(ExplodingDict({"data": {}}), ["data", "user"], default=None)
+
+    @patch("utils.github_api.requests.get")
+    def test_fetch_sparkline_data_skips_malformed_events(self, mock_get):
+        today = date.today().strftime("%Y-%m-%d")
+        mock_get.return_value = FakeResponse(
+            200,
+            [
+                {"type": "PushEvent", "created_at": f"{today}T12:00:00Z", "payload": {"distinct_size": 3}},
+                {"type": "PushEvent", "created_at": f"{today}T13:00:00Z", "payload": None},
+                {"type": "PushEvent"},
+                "not-a-dict",
+            ],
+        )
+
+        counts = fetch_sparkline_data("octocat")
+
+        self.assertEqual(len(counts), 30)
+        self.assertGreaterEqual(counts[-1], 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/api_validators.py
+++ b/utils/api_validators.py
@@ -255,7 +255,7 @@ def safe_get_nested_value(data: Dict[str, Any], path: List[str], default: Any = 
                 return default
             current = current[key]
         return current
-    except Exception:
+    except (AttributeError, KeyError, IndexError, TypeError):
         return default
 
 

--- a/utils/github_api.py
+++ b/utils/github_api.py
@@ -7,7 +7,7 @@ import streamlit as st
 
 try:
     from dotenv import load_dotenv
-except Exception:
+except ImportError:
     load_dotenv = None
 
 from utils.logger import setup_logger, log_api_call
@@ -109,7 +109,7 @@ def fetch_github_graphql(username, token=None):
     if not token:
         try:
             token = st.secrets.get("GITHUB_TOKEN")
-        except Exception:
+        except (AttributeError, KeyError, RuntimeError, TypeError):
             token = None
         if not token:
             token = os.getenv("GITHUB_TOKEN")
@@ -262,7 +262,7 @@ def get_github_headers(token=None):
     if not token:
         try:
             token = st.secrets.get("GITHUB_TOKEN")
-        except Exception:
+        except (AttributeError, KeyError, RuntimeError, TypeError):
             token = None
         if not token:
             token = os.getenv("GITHUB_TOKEN")
@@ -599,12 +599,16 @@ def fetch_sparkline_data(username, token=None):
         if response.status_code == 200:
             events = response.json()
             for event in events:
-                if event['type'] == 'PushEvent':
-                    date = event['created_at'].split('T')[0]
-                    if date in daily_commits:
-                        daily_commits[date] += event['payload'].get('distinct_size', 0)
-    except:
-        pass
+                try:
+                    if event.get('type') == 'PushEvent':
+                        date = event.get('created_at', '').split('T')[0]
+                        if date in daily_commits:
+                            daily_commits[date] += event.get('payload', {}).get('distinct_size', 0)
+                except (AttributeError, KeyError, TypeError) as e:
+                    logger.warning(f"Skipping malformed event for {username}: {e}")
+                    continue
+    except (requests.RequestException, ValueError, TypeError) as e:
+        logger.warning(f"Failed to fetch sparkline data for {username}: {e}")
     
     # Return as a list of counts from oldest to newest
     return [daily_commits[date] for date in reversed(dates)]
@@ -628,7 +632,7 @@ def get_github_actions_data(username, token=None):
         # Try to get token from streamlit secrets or environment
         try:
             token = st.secrets.get("GITHUB_TOKEN")
-        except Exception:
+        except (AttributeError, KeyError, RuntimeError, TypeError):
             # Secrets file not found or not accessible
             token = None
         


### PR DESCRIPTION
I replaced the silent bare exception handlers in ai_roast_service.py, generative.py, contrib_card.py, contrib_card_MERGED.py, trophy_card.py, api_validators.py, and github_api.py. The date parsing and sparkline event loops now skip malformed input with specific exception types, and the GitHub API secret lookups and import fallbacks are bounded to expected failures instead of swallowing everything.

I also added test_exception_handling_unit.py to cover invalid dates, malformed GitHub events, and unsafe nested lookups. Validation passed with `python -m unittest test_exception_handling_unit`, and the repository-wide exact-pattern check found no remaining matches for the bare forms `except Exception:` or `except:`.

closes #245