### PR TITLE
fix: production errors

### DIFF
--- a/ai/ai_roast_service.py
+++ b/ai/ai_roast_service.py
@@ -10,7 +10,7 @@ from config.settings import get_settings
 try:
     import google.generativeai as genai  # type: ignore
     _HAS_GENAI = True
-except Exception:
+except ImportError:
     genai = None
     _HAS_GENAI = False
 from openai import OpenAI

--- a/ai/generative.py
+++ b/ai/generative.py
@@ -11,7 +11,7 @@ import logging
 try:
     import google.generativeai as genai
     _HAS_GENAI = True
-except Exception:
+except ImportError:
     genai = None
     _HAS_GENAI = False
 

--- a/generators/contrib_card.py
+++ b/generators/contrib_card.py
@@ -53,7 +53,7 @@ def _latest_contribution_date(contributions):
             continue
         try:
             parsed = date.fromisoformat(item_date)
-        except Exception:
+        except (TypeError, ValueError):
             continue
         if not max_date or parsed > max_date:
             max_date = parsed
@@ -132,7 +132,7 @@ def _weeks_to_cells(weeks, cols, rows, max_date):
             if item_date:
                 try:
                     parsed = date.fromisoformat(item_date)
-                except Exception:
+                except (TypeError, ValueError):
                     parsed = None
             is_future = bool(max_date and parsed and parsed > max_date)
             cells.append({
@@ -153,7 +153,7 @@ def _add_timeline_labels(dwg, weeks, cols, rows, start_x, start_y, box_size, gap
         if day and day.get("date"):
             try:
                 day_date = date.fromisoformat(day["date"])
-            except Exception:
+            except (TypeError, ValueError):
                 day_date = None
 
         if not day_date:

--- a/generators/contrib_card_MERGED.py
+++ b/generators/contrib_card_MERGED.py
@@ -49,7 +49,7 @@ def _latest_contribution_date(contributions):
             continue
         try:
             parsed = date.fromisoformat(item_date)
-        except Exception:
+        except (TypeError, ValueError):
             continue
         if not max_date or parsed > max_date:
             max_date = parsed
@@ -71,7 +71,7 @@ def _weeks_from_dates(contributions, cols, rows):
             continue
         try:
             parsed = date.fromisoformat(item_date)
-        except Exception:
+        except (TypeError, ValueError):
             continue
         date_counts[parsed] = item.get("count", 0)
 
@@ -126,7 +126,7 @@ def _weeks_to_cells(weeks, cols, rows, max_date):
             if item_date:
                 try:
                     parsed = date.fromisoformat(item_date)
-                except Exception:
+                except (TypeError, ValueError):
                     parsed = None
             is_future = bool(max_date and parsed and parsed > max_date)
             cells.append({
@@ -147,7 +147,7 @@ def _add_timeline_labels(dwg, weeks, cols, rows, start_x, start_y, box_size, gap
         if day and day.get("date"):
             try:
                 day_date = date.fromisoformat(day["date"])
-            except Exception:
+            except (TypeError, ValueError):
                 day_date = None
 
         if not day_date:

--- a/generators/trophy_card.py
+++ b/generators/trophy_card.py
@@ -23,7 +23,7 @@ def draw_trophy_card(data, theme_name="Default", custom_colors=None):
             years_contributing = (datetime.now() - created_date).days // 365
             if years_contributing < 1:
                 years_contributing = 1
-        except Exception:
+        except (TypeError, ValueError):
             years_contributing = 1
     
     # Determine repository quality tier

--- a/test_error_handling.py
+++ b/test_error_handling.py
@@ -11,16 +11,21 @@ This script tests:
 
 import requests
 import json
+import os
 from datetime import datetime
+
+from utils.logger import setup_logger
 
 # API base URL
 API_BASE = "http://localhost:8000"
+VERBOSE_TESTS = os.getenv("VERBOSE_TESTS") == "1"
+logger = setup_logger(__name__, level="INFO" if VERBOSE_TESTS else "WARNING")
 
 def test_nonexistent_user():
     """Test API response for non-existent username"""
-    print("\n" + "="*60)
-    print("TEST 1: Non-existent User Handling")
-    print("="*60)
+    logger.info("\n%s", "=" * 60)
+    logger.info("TEST 1: Non-existent User Handling")
+    logger.info("%s", "=" * 60)
     
     username = "nonexistentuser_" + datetime.now().strftime("%Y%m%d%H%M%S")
     endpoints = [
@@ -39,29 +44,29 @@ def test_nonexistent_user():
             
             # Check status code
             if response.status_code == 502:
-                print(f"✓ {endpoint}: Correctly returns 502 Bad Gateway")
+                logger.info("PASS %s: Correctly returns 502 Bad Gateway", endpoint)
                 # Check for error header
                 if response.headers.get("X-Error"):
-                    print(f"  ✓ Error header present: {response.headers.get('X-Error')}")
+                    logger.info("  Error header present: %s", response.headers.get("X-Error"))
                 # Check content type is SVG
                 if "image/svg+xml" in response.headers.get("Content-Type", ""):
-                    print(f"  ✓ Returns SVG error card")
+                    logger.info("  Returns SVG error card")
                 else:
-                    print(f"  ✗ Wrong content type: {response.headers.get('Content-Type')}")
+                    logger.error("  Wrong content type: %s", response.headers.get("Content-Type"))
             elif response.status_code == 200:
-                print(f"✗ {endpoint}: Returns 200 (should be 502) - FALLBACK TO MOCK DATA DETECTED")
+                logger.error("FAIL %s: Returns 200 (should be 502) - FALLBACK TO MOCK DATA DETECTED", endpoint)
             else:
-                print(f"? {endpoint}: Returns {response.status_code}")
+                logger.warning("%s: Returns %s", endpoint, response.status_code)
                 
         except Exception as e:
-            print(f"✗ {endpoint}: Error - {e}")
+            logger.error("FAIL %s: Error - %s", endpoint, e)
 
 
 def test_actions_without_auth():
     """Test Actions endpoint requires authentication"""
-    print("\n" + "="*60)
-    print("TEST 2: GitHub Actions Authentication")
-    print("="*60)
+    logger.info("\n%s", "=" * 60)
+    logger.info("TEST 2: GitHub Actions Authentication")
+    logger.info("%s", "=" * 60)
     
     url = f"{API_BASE}/api/actions?username=torvalds"
     
@@ -70,23 +75,23 @@ def test_actions_without_auth():
         response = requests.get(url, timeout=10)
         
         if response.status_code == 401:
-            print(f"✓ Actions endpoint correctly returns 401 without token")
+            logger.info("PASS Actions endpoint correctly returns 401 without token")
             if "Unauthorized" in response.text or "authentication" in response.text.lower():
-                print(f"  ✓ Error message mentions authentication")
+                logger.info("  Error message mentions authentication")
         elif response.status_code == 200:
-            print(f"✗ Actions endpoint returns 200 (should require auth) - MOCK DATA RETURNED")
+            logger.error("FAIL Actions endpoint returns 200 (should require auth) - MOCK DATA RETURNED")
         else:
-            print(f"? Actions endpoint returns {response.status_code}")
+            logger.warning("Actions endpoint returns %s", response.status_code)
             
     except Exception as e:
-        print(f"✗ Error: {e}")
+        logger.error("FAIL Error: %s", e)
 
 
 def test_actions_with_auth():
     """Test Actions endpoint with authentication"""
-    print("\n" + "="*60)
-    print("TEST 3: GitHub Actions with Authentication")
-    print("="*60)
+    logger.info("\n%s", "=" * 60)
+    logger.info("TEST 3: GitHub Actions with Authentication")
+    logger.info("%s", "=" * 60)
     
     # Using a non-existent user with token to test error handling
     url = f"{API_BASE}/api/actions?username=nonexistentuser_test"
@@ -98,23 +103,23 @@ def test_actions_with_auth():
         response = requests.get(url, headers=headers, timeout=10)
         
         if response.status_code == 502:
-            print(f"✓ Actions endpoint with invalid user returns 502")
+            logger.info("PASS Actions endpoint with invalid user returns 502")
             if response.headers.get("X-Error"):
-                print(f"  ✓ Error header present: {response.headers.get('X-Error')}")
+                logger.info("  Error header present: %s", response.headers.get("X-Error"))
         elif response.status_code == 200:
-            print(f"✗ Actions endpoint returns 200 (should return error for nonexistent user)")
+            logger.error("FAIL Actions endpoint returns 200 (should return error for nonexistent user)")
         else:
-            print(f"? Actions endpoint returns {response.status_code}")
+            logger.warning("Actions endpoint returns %s", response.status_code)
             
     except Exception as e:
-        print(f"✗ Error: {e}")
+        logger.error("FAIL Error: %s", e)
 
 
 def test_error_response_format():
     """Test that error responses are valid SVG"""
-    print("\n" + "="*60)
-    print("TEST 4: Error Response Format")
-    print("="*60)
+    logger.info("\n%s", "=" * 60)
+    logger.info("TEST 4: Error Response Format")
+    logger.info("%s", "=" * 60)
     
     url = f"{API_BASE}/api/stats?username=invalid_user_12345"
     
@@ -126,28 +131,28 @@ def test_error_response_format():
             
             # Check if it's valid SVG
             if content.startswith("<svg") and "</svg>" in content:
-                print(f"✓ Error response is valid SVG")
+                logger.info("PASS Error response is valid SVG")
                 
                 # Check for error indicators
                 if "Error" in content or "error" in content.lower():
-                    print(f"  ✓ SVG contains error message")
+                    logger.info("  SVG contains error message")
                 if "!" in content or "exclamation" in content.lower():
-                    print(f"  ✓ SVG contains error icon/indicator")
+                    logger.info("  SVG contains error icon/indicator")
             else:
-                print(f"✗ Response is not valid SVG")
-                print(f"  First 200 chars: {content[:200]}")
+                logger.error("FAIL Response is not valid SVG")
+                logger.error("  First 200 chars: %s", content[:200])
         else:
-            print(f"? Status {response.status_code}, Content-Type: {response.headers.get('Content-Type')}")
+            logger.warning("Status %s, Content-Type: %s", response.status_code, response.headers.get('Content-Type'))
             
     except Exception as e:
-        print(f"✗ Error: {e}")
+        logger.error("FAIL Error: %s", e)
 
 
 def test_cache_not_caching_errors():
     """Test that error responses are not cached"""
-    print("\n" + "="*60)
-    print("TEST 5: Error Response Caching")
-    print("="*60)
+    logger.info("\n%s", "=" * 60)
+    logger.info("TEST 5: Error Response Caching")
+    logger.info("%s", "=" * 60)
     
     url = f"{API_BASE}/api/stats?username=nonexistent_user_cache_test"
     
@@ -159,21 +164,21 @@ def test_cache_not_caching_errors():
         cache_control_2 = response2.headers.get("Cache-Control")
         
         if "no-cache" in cache_control_1 or "no-store" in cache_control_1:
-            print(f"✓ Error responses are not cached")
-            print(f"  Cache-Control: {cache_control_1}")
+            logger.info("PASS Error responses are not cached")
+            logger.info("  Cache-Control: %s", cache_control_1)
         else:
-            print(f"✗ Error responses may be cached")
-            print(f"  Cache-Control: {cache_control_1}")
+            logger.error("FAIL Error responses may be cached")
+            logger.error("  Cache-Control: %s", cache_control_1)
             
     except Exception as e:
-        print(f"✗ Error: {e}")
+        logger.error("FAIL Error: %s", e)
 
 
 def test_valid_user_returns_200():
     """Test that valid users still return 200 OK"""
-    print("\n" + "="*60)
-    print("TEST 6: Valid User Returns Success")
-    print("="*60)
+    logger.info("\n%s", "=" * 60)
+    logger.info("TEST 6: Valid User Returns Success")
+    logger.info("%s", "=" * 60)
     
     # Using a well-known GitHub user
     url = f"{API_BASE}/api/stats?username=torvalds"
@@ -182,33 +187,33 @@ def test_valid_user_returns_200():
         response = requests.get(url, timeout=10)
         
         if response.status_code == 200:
-            print(f"✓ Valid user returns 200 OK")
+            logger.info("PASS Valid user returns 200 OK")
             if "image/svg+xml" in response.headers.get("Content-Type", ""):
-                print(f"  ✓ Returns SVG content")
+                logger.info("  Returns SVG content")
         else:
-            print(f"? Valid user returns {response.status_code}")
+            logger.warning("Valid user returns %s", response.status_code)
             if response.status_code == 502:
-                print(f"  ✗ GitHub API might be rate-limited or unavailable")
+                logger.error("  GitHub API might be rate-limited or unavailable")
             
     except Exception as e:
-        print(f"✗ Error: {e}")
+        logger.error("FAIL Error: %s", e)
 
 
 if __name__ == "__main__":
-    print("\n🧪 GitCanvas Error Handling Test Suite")
-    print("Testing API error responses and exception handling")
+    logger.info("\nGitCanvas Error Handling Test Suite")
+    logger.info("Testing API error responses and exception handling")
     
     try:
         # Quick health check
         response = requests.get(f"{API_BASE}/", timeout=5)
         if response.status_code == 200:
-            print(f"✓ API is running at {API_BASE}")
+            logger.info("PASS API is running at %s", API_BASE)
         else:
-            print(f"✗ API health check failed: {response.status_code}")
+            logger.error("FAIL API health check failed: %s", response.status_code)
             exit(1)
     except Exception as e:
-        print(f"✗ Cannot reach API at {API_BASE}: {e}")
-        print("Make sure the API is running: uvicorn api.main:app --reload")
+        logger.error("FAIL Cannot reach API at %s: %s", API_BASE, e)
+        logger.error("Make sure the API is running: uvicorn api.main:app --reload")
         exit(1)
     
     # Run tests
@@ -219,6 +224,6 @@ if __name__ == "__main__":
     test_cache_not_caching_errors()
     test_valid_user_returns_200()
     
-    print("\n" + "="*60)
-    print("✅ Test suite complete!")
-    print("="*60 + "\n")
+    logger.info("\n%s", "=" * 60)
+    logger.info("Test suite complete!")
+    logger.info("%s\n", "=" * 60)

--- a/test_exception_handling_unit.py
+++ b/test_exception_handling_unit.py
@@ -1,0 +1,61 @@
+import unittest
+from datetime import date, timedelta
+from unittest.mock import patch
+
+from generators.contrib_card import _latest_contribution_date
+from utils.api_validators import safe_get_nested_value
+from utils.github_api import fetch_sparkline_data
+
+
+class ExplodingDict(dict):
+    def __getitem__(self, key):
+        raise RuntimeError("boom")
+
+
+class FakeResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class ExceptionHandlingTests(unittest.TestCase):
+    def test_latest_contribution_date_skips_invalid_dates(self):
+        valid_date = date.today() - timedelta(days=2)
+        newer_valid_date = date.today() - timedelta(days=1)
+        contributions = [
+            {"date": "not-a-date", "count": 1},
+            {"date": valid_date.isoformat(), "count": 2},
+            {"date": None, "count": 3},
+            {"date": newer_valid_date.isoformat(), "count": 4},
+        ]
+
+        self.assertEqual(_latest_contribution_date(contributions), newer_valid_date)
+
+    def test_safe_get_nested_value_does_not_swallow_runtime_errors(self):
+        with self.assertRaises(RuntimeError):
+            safe_get_nested_value(ExplodingDict({"data": {}}), ["data", "user"], default=None)
+
+    @patch("utils.github_api.requests.get")
+    def test_fetch_sparkline_data_skips_malformed_events(self, mock_get):
+        today = date.today().strftime("%Y-%m-%d")
+        mock_get.return_value = FakeResponse(
+            200,
+            [
+                {"type": "PushEvent", "created_at": f"{today}T12:00:00Z", "payload": {"distinct_size": 3}},
+                {"type": "PushEvent", "created_at": f"{today}T13:00:00Z", "payload": None},
+                {"type": "PushEvent"},
+                "not-a-dict",
+            ],
+        )
+
+        counts = fetch_sparkline_data("octocat")
+
+        self.assertEqual(len(counts), 30)
+        self.assertGreaterEqual(counts[-1], 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/api_validators.py
+++ b/utils/api_validators.py
@@ -255,7 +255,7 @@ def safe_get_nested_value(data: Dict[str, Any], path: List[str], default: Any = 
                 return default
             current = current[key]
         return current
-    except Exception:
+    except (AttributeError, KeyError, IndexError, TypeError):
         return default
 
 

--- a/utils/github_api.py
+++ b/utils/github_api.py
@@ -7,7 +7,7 @@ import streamlit as st
 
 try:
     from dotenv import load_dotenv
-except Exception:
+except ImportError:
     load_dotenv = None
 
 from utils.logger import setup_logger, log_api_call
@@ -109,7 +109,7 @@ def fetch_github_graphql(username, token=None):
     if not token:
         try:
             token = st.secrets.get("GITHUB_TOKEN")
-        except Exception:
+        except (AttributeError, KeyError, RuntimeError, TypeError):
             token = None
         if not token:
             token = os.getenv("GITHUB_TOKEN")
@@ -262,7 +262,7 @@ def get_github_headers(token=None):
     if not token:
         try:
             token = st.secrets.get("GITHUB_TOKEN")
-        except Exception:
+        except (AttributeError, KeyError, RuntimeError, TypeError):
             token = None
         if not token:
             token = os.getenv("GITHUB_TOKEN")
@@ -599,12 +599,16 @@ def fetch_sparkline_data(username, token=None):
         if response.status_code == 200:
             events = response.json()
             for event in events:
-                if event['type'] == 'PushEvent':
-                    date = event['created_at'].split('T')[0]
-                    if date in daily_commits:
-                        daily_commits[date] += event['payload'].get('distinct_size', 0)
-    except:
-        pass
+                try:
+                    if event.get('type') == 'PushEvent':
+                        date = event.get('created_at', '').split('T')[0]
+                        if date in daily_commits:
+                            daily_commits[date] += event.get('payload', {}).get('distinct_size', 0)
+                except (AttributeError, KeyError, TypeError) as e:
+                    logger.warning(f"Skipping malformed event for {username}: {e}")
+                    continue
+    except (requests.RequestException, ValueError, TypeError) as e:
+        logger.warning(f"Failed to fetch sparkline data for {username}: {e}")
     
     # Return as a list of counts from oldest to newest
     return [daily_commits[date] for date in reversed(dates)]
@@ -628,7 +632,7 @@ def get_github_actions_data(username, token=None):
         # Try to get token from streamlit secrets or environment
         try:
             token = st.secrets.get("GITHUB_TOKEN")
-        except Exception:
+        except (AttributeError, KeyError, RuntimeError, TypeError):
             # Secrets file not found or not accessible
             token = None
         


### PR DESCRIPTION
Updated test_error_handling.py to use `setup_logger(__name__)` instead of `print(...)`, with `VERBOSE_TESTS=1` controlling whether the informational test transcript is emitted. By default it stays quiet and only reports real failures; in verbose mode it restores the step-by-step output.

Validated both modes:
- Default run: only the real API connection error was logged, no banner/spam output.
- `VERBOSE_TESTS=1` run: informational test messages were emitted as expected.

closes #246