### PR TITLE
feat: add Midnight theme with deep night sky colors (Resolves #95)

### DIFF
--- a/app.py
+++ b/app.py
@@ -212,10 +212,13 @@ with st.sidebar:
         default_theme = all_themes.get(selected_theme, all_themes["Default"]).copy() # Copy to avoid mutating global
         
         # Helper to get color safely
-        def get_col(key): return default_theme.get(key, "#000000")
+        def get_col(key):
+            val = default_theme.get(key, "000000")
+            return f"#{val}" if not str(val).startswith("#") else val
         
         # Use theme-specific keys so each theme maintains its own customization
-        custom_bg = st.color_picker("Background", value=get_col("bg_color"), key=f"customize_bg_{selected_theme}")
+        def hex_fix(v): return f"#{v}" if not v.startswith("#") else v
+        custom_bg = st.color_picker("Background", value=hex_fix(get_col("bg_color")), key=f"customize_bg_{selected_theme}")
         
         # Validate HEX color format
         if not HEX_COLOR_REGEX.match(custom_bg):

--- a/themes/json/midnight.json
+++ b/themes/json/midnight.json
@@ -1,0 +1,10 @@
+{
+  "bg_color": "0d1117",
+  "border_color": "1e2d3d",
+  "title_color": "a8d8f0",
+  "text_color": "c9d1d9",
+  "icon_color": "58a6ff",
+  "title_font_size": 20,
+  "text_font_size": 14,
+  "tags": ["dark", "blue", "minimal", "tech", "cool"]
+}

--- a/themes/styles.py
+++ b/themes/styles.py
@@ -106,6 +106,14 @@ import os
 
 themes_dir = os.path.join(os.path.dirname(__file__), 'json')
 
+def normalize_theme_colors(theme_data):
+    """Ensure hex color values include a leading #."""
+    for key, value in theme_data.items():
+        if key.endswith("_color") and isinstance(value, str) and value and not value.startswith("#"):
+            theme_data[key] = f"#{value}"
+    return theme_data
+
+
 def load_predefined_themes():
     """Load predefined themes from JSON files"""
     if os.path.exists(themes_dir):
@@ -113,7 +121,8 @@ def load_predefined_themes():
             if filename.endswith('.json') and not filename.startswith('custom_'):
                 theme_name = filename[:-5].capitalize()  # Remove .json and capitalize
                 with open(os.path.join(themes_dir, filename), 'r') as f:
-                    THEMES[theme_name] = json.load(f)
+                    theme_data = json.load(f)
+                THEMES[theme_name] = normalize_theme_colors(theme_data)
 
 def load_custom_themes():
     """Load custom themes from custom_*.json files"""
@@ -124,7 +133,8 @@ def load_custom_themes():
                 # Extract theme name from custom_{name}.json
                 theme_name = filename[7:-5].capitalize()  # Remove 'custom_' and '.json'
                 with open(os.path.join(themes_dir, filename), 'r') as f:
-                    custom_themes[theme_name] = json.load(f)
+                    theme_data = json.load(f)
+                custom_themes[theme_name] = normalize_theme_colors(theme_data)
     return custom_themes
 
 def save_custom_theme(theme_name, theme_data):


### PR DESCRIPTION
- Contributing on behalf of NSoC'26

##  New Theme: Midnight

Adds a Midnight theme inspired by the night sky — deep dark background 
with cool blue accent colors.

###  Color Palette
| Property      | Hex       | Description              |
|---------------|-----------|--------------------------|
| bg_color      | `#0d1117` | Deep midnight sky        |
| border_color  | `#1e2d3d` | Subtle navy horizon glow |
| title_color   | `#a8d8f0` | Moonlight pale blue      |
| text_color    | `#c9d1d9` | Soft starlight white     |
| icon_color    | `#58a6ff` | Cool electric blue       |

###  Tags
`dark` · `blue` · `minimal` · `tech` · `cool`

###  Bonus Fix
Added `normalize_theme_colors()` in `styles.py` to ensure all theme 
JSON color values always include a leading `#`. This prevents 
`StreamlitAPIException` in `st.color_picker()` for any theme storing 
colors without `#`.

###  Testing
- Midnight appears in Select Theme dropdown 
- Tag filters (`dark`, `blue`, `cool`) show Midnight
- Customize Colors panel opens without errors 
- Card preview renders correctly 

Resolves #95

@devanshi14malhotra please review 