### PR TITLE
fix: Brittle Hardcoded Relative Paths in Theme Loader

### DIFF
--- a/test_theme_loader.py
+++ b/test_theme_loader.py
@@ -1,0 +1,35 @@
+import os
+import json
+import subprocess
+import unittest
+from pathlib import Path
+import tempfile
+
+
+class ThemeLoaderTests(unittest.TestCase):
+    def test_import_and_load_custom_themes_are_cwd_independent(self):
+        repo_root = Path(__file__).resolve().parent
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env = os.environ.copy()
+            env["PYTHONPATH"] = str(repo_root) + os.pathsep + env.get("PYTHONPATH", "")
+
+            result = subprocess.run(
+                [
+                    os.sys.executable,
+                    "-c",
+                    "from themes.styles import *; import json; print(json.dumps(load_custom_themes()))",
+                ],
+                cwd=temp_dir,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+        custom_themes = json.loads(result.stdout)
+        self.assertIsInstance(custom_themes, dict)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/themes/styles.py
+++ b/themes/styles.py
@@ -83,30 +83,29 @@ THEMES = {
     }
 }
 import json
-import os
+from pathlib import Path
 
 
-themes_dir = os.path.join(os.path.dirname(__file__), 'json')
+themes_dir = Path(__file__).parent / "json"
+themes_dir.mkdir(exist_ok=True)
 
 def load_predefined_themes():
     """Load predefined themes from JSON files"""
-    if os.path.exists(themes_dir):
-        for filename in os.listdir(themes_dir):
-            if filename.endswith('.json') and not filename.startswith('custom_'):
-                theme_name = filename[:-5].capitalize()  # Remove .json and capitalize
-                with open(os.path.join(themes_dir, filename), 'r') as f:
-                    THEMES[theme_name] = json.load(f)
+    for theme_file in themes_dir.iterdir():
+        if theme_file.is_file() and theme_file.suffix == ".json" and not theme_file.name.startswith("custom_"):
+            theme_name = theme_file.stem.capitalize()  # Remove .json and capitalize
+            with theme_file.open('r') as f:
+                THEMES[theme_name] = json.load(f)
 
 def load_custom_themes():
     """Load custom themes from custom_*.json files"""
     custom_themes = {}
-    if os.path.exists(themes_dir):
-        for filename in os.listdir(themes_dir):
-            if filename.startswith('custom_') and filename.endswith('.json'):
-                # Extract theme name from custom_{name}.json
-                theme_name = filename[7:-5].capitalize()  # Remove 'custom_' and '.json'
-                with open(os.path.join(themes_dir, filename), 'r') as f:
-                    custom_themes[theme_name] = json.load(f)
+    for theme_file in themes_dir.iterdir():
+        if theme_file.is_file() and theme_file.name.startswith('custom_') and theme_file.suffix == '.json':
+            # Extract theme name from custom_{name}.json
+            theme_name = theme_file.stem[7:].capitalize()  # Remove 'custom_' and '.json'
+            with theme_file.open('r') as f:
+                custom_themes[theme_name] = json.load(f)
     return custom_themes
 
 def save_custom_theme(theme_name, theme_data):
@@ -114,9 +113,9 @@ def save_custom_theme(theme_name, theme_data):
     # Sanitize theme name for filename
     safe_name = theme_name.lower().replace(' ', '_').replace('-', '_')
     filename = f"custom_{safe_name}.json"
-    filepath = os.path.join(themes_dir, filename)
+    filepath = themes_dir / filename
     
-    with open(filepath, 'w') as f:
+    with filepath.open('w') as f:
         json.dump(theme_data, f, indent=4)
     
     return filename


### PR DESCRIPTION
Updated styles.py to resolve the theme JSON folder with `Path(__file__).parent / "json"` and create it up front with `mkdir(exist_ok=True)`. The loader and saver now use `Path` objects directly, so the import no longer depends on CWD.

Added test_theme_loader.py to exercise the exact import pattern from a different working directory in a fresh process. Validation passed with `python -m unittest test_theme_loader`.

closes #247