### PR TITLE
feat: add 9 new themes - Minimalist, Calming and Aesthetic (Resolves #99)

### DIFF
--- a/app.py
+++ b/app.py
@@ -212,10 +212,13 @@ with st.sidebar:
         default_theme = all_themes.get(selected_theme, all_themes["Default"]).copy() # Copy to avoid mutating global
         
         # Helper to get color safely
-        def get_col(key): return default_theme.get(key, "#000000")
+        def get_col(key):
+            val = default_theme.get(key, "000000")
+            return f"#{val}" if not str(val).startswith("#") else val
         
         # Use theme-specific keys so each theme maintains its own customization
-        custom_bg = st.color_picker("Background", value=get_col("bg_color"), key=f"customize_bg_{selected_theme}")
+        def hex_fix(v): return f"#{v}" if not v.startswith("#") else v
+        custom_bg = st.color_picker("Background", value=hex_fix(get_col("bg_color")), key=f"customize_bg_{selected_theme}")
         
         # Validate HEX color format
         if not HEX_COLOR_REGEX.match(custom_bg):

--- a/themes/json/aesthetic_glass.json
+++ b/themes/json/aesthetic_glass.json
@@ -1,0 +1,16 @@
+{
+    "bg_color": "0f0f1a",
+    "border_color": "334466",
+    "title_color": "e0eeff",
+    "text_color": "a8bcd0",
+    "icon_color": "88aadd",
+    "title_font_size": 20,
+    "text_font_size": 14,
+    "tags": [
+        "dark",
+        "blue",
+        "minimal",
+        "tech",
+        "aesthetic"
+    ]
+}

--- a/themes/json/aesthetic_neon.json
+++ b/themes/json/aesthetic_neon.json
@@ -1,0 +1,15 @@
+{
+    "bg_color": "0d0d0d",
+    "border_color": "ff00ff",
+    "title_color": "ff00ff",
+    "text_color": "e0e0e0",
+    "icon_color": "00ffff",
+    "title_font_size": 20,
+    "text_font_size": 14,
+    "tags": [
+        "dark",
+        "neon",
+        "colorful",
+        "aesthetic"
+    ]
+}

--- a/themes/json/aesthetic_sunset.json
+++ b/themes/json/aesthetic_sunset.json
@@ -1,0 +1,16 @@
+{
+    "bg_color": "1a0a1a",
+    "border_color": "ff6b35",
+    "title_color": "ff9f68",
+    "text_color": "f0d0b0",
+    "icon_color": "ff6b35",
+    "title_font_size": 20,
+    "text_font_size": 14,
+    "tags": [
+        "dark",
+        "red",
+        "colorful",
+        "neon",
+        "aesthetic"
+    ]
+}

--- a/themes/json/calm_lavender.json
+++ b/themes/json/calm_lavender.json
@@ -1,0 +1,15 @@
+{
+    "bg_color": "f3eef8",
+    "border_color": "d4b8e8",
+    "title_color": "6a3d9a",
+    "text_color": "4a3060",
+    "icon_color": "9c6bc4",
+    "title_font_size": 20,
+    "text_font_size": 14,
+    "tags": [
+        "light",
+        "purple",
+        "minimal",
+        "calm"
+    ]
+}

--- a/themes/json/calm_ocean.json
+++ b/themes/json/calm_ocean.json
@@ -1,0 +1,15 @@
+{
+    "bg_color": "e8f4f8",
+    "border_color": "b2d8e8",
+    "title_color": "1a6b8a",
+    "text_color": "2c4a52",
+    "icon_color": "2196a6",
+    "title_font_size": 20,
+    "text_font_size": 14,
+    "tags": [
+        "light",
+        "blue",
+        "minimal",
+        "calm"
+    ]
+}

--- a/themes/json/calm_sand.json
+++ b/themes/json/calm_sand.json
@@ -1,0 +1,15 @@
+{
+    "bg_color": "faf3e0",
+    "border_color": "e8d5a3",
+    "title_color": "8b6914",
+    "text_color": "5c4a1e",
+    "icon_color": "c8a84b",
+    "title_font_size": 20,
+    "text_font_size": 14,
+    "tags": [
+        "light",
+        "minimal",
+        "calm",
+        "colorful"
+    ]
+}

--- a/themes/json/midnight.json
+++ b/themes/json/midnight.json
@@ -1,0 +1,10 @@
+{
+  "bg_color": "0d1117",
+  "border_color": "1e2d3d",
+  "title_color": "a8d8f0",
+  "text_color": "c9d1d9",
+  "icon_color": "58a6ff",
+  "title_font_size": 20,
+  "text_font_size": 14,
+  "tags": ["dark", "blue", "minimal", "tech", "cool"]
+}

--- a/themes/json/minimal_dark.json
+++ b/themes/json/minimal_dark.json
@@ -1,0 +1,10 @@
+{
+  "bg_color": "0a0a0a",
+  "border_color": "222222",
+  "title_color": "f0f0f0",
+  "text_color": "cccccc",
+  "icon_color": "888888",
+  "title_font_size": 20,
+  "text_font_size": 14,
+  "tags": ["dark", "minimal", "clean"]
+}

--- a/themes/json/minimal_dark.json
+++ b/themes/json/minimal_dark.json
@@ -1,10 +1,14 @@
 {
-  "bg_color": "0a0a0a",
-  "border_color": "222222",
-  "title_color": "f0f0f0",
-  "text_color": "cccccc",
-  "icon_color": "888888",
-  "title_font_size": 20,
-  "text_font_size": 14,
-  "tags": ["dark", "minimal", "clean"]
+    "bg_color": "0a0a0a",
+    "border_color": "222222",
+    "title_color": "f0f0f0",
+    "text_color": "cccccc",
+    "icon_color": "888888",
+    "title_font_size": 20,
+    "text_font_size": 14,
+    "tags": [
+        "dark",
+        "minimal",
+        "clean"
+    ]
 }

--- a/themes/json/minimal_light.json
+++ b/themes/json/minimal_light.json
@@ -1,10 +1,14 @@
 {
-  "bg_color": "f8f8f8",
-  "border_color": "e0e0e0",
-  "title_color": "111111",
-  "text_color": "333333",
-  "icon_color": "555555",
-  "title_font_size": 20,
-  "text_font_size": 14,
-  "tags": ["light", "minimal", "clean"]
+    "bg_color": "f8f8f8",
+    "border_color": "e0e0e0",
+    "title_color": "111111",
+    "text_color": "333333",
+    "icon_color": "555555",
+    "title_font_size": 20,
+    "text_font_size": 14,
+    "tags": [
+        "light",
+        "minimal",
+        "clean"
+    ]
 }

--- a/themes/json/minimal_light.json
+++ b/themes/json/minimal_light.json
@@ -1,0 +1,10 @@
+{
+  "bg_color": "f8f8f8",
+  "border_color": "e0e0e0",
+  "title_color": "111111",
+  "text_color": "333333",
+  "icon_color": "555555",
+  "title_font_size": 20,
+  "text_font_size": 14,
+  "tags": ["light", "minimal", "clean"]
+}

--- a/themes/json/minimal_mono.json
+++ b/themes/json/minimal_mono.json
@@ -1,10 +1,15 @@
 {
-  "bg_color": "ffffff",
-  "border_color": "000000",
-  "title_color": "000000",
-  "text_color": "444444",
-  "icon_color": "000000",
-  "title_font_size": 20,
-  "text_font_size": 14,
-  "tags": ["light", "minimal", "clean", "tech"]
+    "bg_color": "ffffff",
+    "border_color": "000000",
+    "title_color": "000000",
+    "text_color": "444444",
+    "icon_color": "000000",
+    "title_font_size": 20,
+    "text_font_size": 14,
+    "tags": [
+        "light",
+        "minimal",
+        "clean",
+        "tech"
+    ]
 }

--- a/themes/json/minimal_mono.json
+++ b/themes/json/minimal_mono.json
@@ -1,0 +1,10 @@
+{
+  "bg_color": "ffffff",
+  "border_color": "000000",
+  "title_color": "000000",
+  "text_color": "444444",
+  "icon_color": "000000",
+  "title_font_size": 20,
+  "text_font_size": 14,
+  "tags": ["light", "minimal", "clean", "tech"]
+}

--- a/themes/styles.py
+++ b/themes/styles.py
@@ -106,6 +106,14 @@ import os
 
 themes_dir = os.path.join(os.path.dirname(__file__), 'json')
 
+def normalize_theme_colors(theme_data):
+    """Ensure hex color values include a leading #."""
+    for key, value in theme_data.items():
+        if key.endswith("_color") and isinstance(value, str) and value and not value.startswith("#"):
+            theme_data[key] = f"#{value}"
+    return theme_data
+
+
 def load_predefined_themes():
     """Load predefined themes from JSON files"""
     if os.path.exists(themes_dir):
@@ -113,7 +121,8 @@ def load_predefined_themes():
             if filename.endswith('.json') and not filename.startswith('custom_'):
                 theme_name = filename[:-5].capitalize()  # Remove .json and capitalize
                 with open(os.path.join(themes_dir, filename), 'r') as f:
-                    THEMES[theme_name] = json.load(f)
+                    theme_data = json.load(f)
+                THEMES[theme_name] = normalize_theme_colors(theme_data)
 
 def load_custom_themes():
     """Load custom themes from custom_*.json files"""
@@ -124,7 +133,8 @@ def load_custom_themes():
                 # Extract theme name from custom_{name}.json
                 theme_name = filename[7:-5].capitalize()  # Remove 'custom_' and '.json'
                 with open(os.path.join(themes_dir, filename), 'r') as f:
-                    custom_themes[theme_name] = json.load(f)
+                    theme_data = json.load(f)
+                custom_themes[theme_name] = normalize_theme_colors(theme_data)
     return custom_themes
 
 def save_custom_theme(theme_name, theme_data):


### PR DESCRIPTION
- Contributing on behalf of NSoC'26

##  9 New Themes Added

###  Minimalist Themes
- `minimal_light` — light clean monochrome
- `minimal_dark` — dark clean monochrome  
- `minimal_mono` — pure black & white

###  Calming Themes
- `calm_ocean` — soft blue pastels
- `calm_lavender` — soft purple pastels
- `calm_sand` — warm beige pastels

###  Aesthetic Themes
- `aesthetic_glass` — dark glassmorphism blue
- `aesthetic_neon` — dark neon cyan/magenta
- `aesthetic_sunset` — dark warm orange glow

###  Testing
- All 9 themes load correctly
- Tag filters work (`calm`, `minimal`, `aesthetic`) 
- Card preview renders correctly 

<img width="1919" height="869" alt="image" src="https://github.com/user-attachments/assets/e360b7e4-6832-4e69-99ca-6f973935cb8c" />


<img width="1919" height="874" alt="image" src="https://github.com/user-attachments/assets/38d84210-12e7-4811-bac8-753df58f73e6" />



Resolves #99


@devanshi14malhotra please review and please add as level3 these one 