### PR TITLE
fix: StreamlitAPI error

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ from roast_widget_streamlit import render_roast_widget
 from generators import stats_card, lang_card, contrib_card, badge_generator, recent_activity_card, streak_card, repo_card, social_card, trophy_card, sparkline, actions_card, commit_analysis_card, gist_card
 from utils import github_api
 from utils.cache import clear_cache as clear_ttl_cache
+from utils.theme_state import reset_theme_filter_state
 from themes.styles import THEMES, get_all_themes, CUSTOM_THEMES
 from generators.visual_elements import (
     emoji_element,
@@ -94,9 +95,14 @@ with st.sidebar:
     # Customization Expander
     # Ensure custom_colors exists even if the expander isn't opened
     custom_colors = {}
+    theme_defaults = all_themes.get(selected_theme, all_themes["Default"]).copy()
+
+    def _reset_theme_filters():
+        reset_theme_filter_state(st.session_state, selected_theme, theme_defaults)
+
     with st.expander("Customize Colors", expanded=False):
         st.caption("Override theme defaults")
-        default_theme = all_themes.get(selected_theme, all_themes["Default"]).copy() # Copy to avoid mutating global
+        default_theme = theme_defaults  # Copy already taken above to avoid mutating global
         
         # Helper to get color safely
         def get_col(key): return default_theme.get(key, "#000000")
@@ -136,6 +142,13 @@ with st.sidebar:
         if custom_title != get_col("title_color"): custom_colors["title_color"] = custom_title
         if custom_text != get_col("text_color"): custom_colors["text_color"] = custom_text
         if custom_border != get_col("border_color"): custom_colors["border_color"] = custom_border
+
+        st.button(
+            "Reset Theme Filters",
+            use_container_width=True,
+            on_click=_reset_theme_filters,
+            help="Restore this theme's color controls to their default values",
+        )
 
     # Custom Theme Creator Section
     with st.expander("🎨 Custom Theme Creator", expanded=False):

--- a/app.py
+++ b/app.py
@@ -17,7 +17,8 @@ from themes.styles import THEMES, get_all_themes, CUSTOM_THEMES
 from generators.visual_elements import (
     emoji_element,
     gif_element,
-    sticker_element
+    sticker_element,
+    create_composite_canvas
 )
 
 
@@ -62,6 +63,12 @@ st.markdown("""
 
 st.title("GitCanvas: Profile Architect 🛠️")
 st.markdown("### Design your GitHub Stats. Copy the Code. Done.")
+
+# Initialize session state for canvas
+if "canvas" not in st.session_state:
+    st.session_state["canvas"] = []
+if "canvas_elements_metadata" not in st.session_state:
+    st.session_state["canvas_elements_metadata"] = []
 
 
 
@@ -724,25 +731,182 @@ with tab10:
     st.subheader("✨ Visual Elements")
     st.markdown("Add emojis, GIFs, or stickers to your canvas")
 
-    element_type = st.selectbox(
-        "Choose element type",
-        ["Emoji", "GIF", "Sticker"]
-    )
-
-    value = st.text_input(
-        "Enter value",
-        placeholder="🔥 or https://gif-url"
-    )
-
-    if st.button("Add to Canvas"):
-        if element_type == "Emoji":
-            svg = emoji_element(value)
-        elif element_type == "GIF":
-            svg = gif_element(value)
+    # --- Canvas Input Section ---
+    col_input1, col_input2, col_input3 = st.columns([2, 2, 1.5])
+    
+    with col_input1:
+        element_type = st.selectbox(
+            "Choose element type",
+            ["Emoji", "GIF", "Sticker"]
+        )
+    
+    with col_input2:
+        value = st.text_input(
+            "Enter value",
+            placeholder="🔥 or https://gif-url"
+        )
+    
+    with col_input3:
+        add_button = st.button("Add to Canvas", use_container_width=True)
+    
+    # Add element to canvas
+    if add_button:
+        if value:
+            if element_type == "Emoji":
+                svg = emoji_element(value)
+            elif element_type == "GIF":
+                svg = gif_element(value)
+            else:
+                svg = sticker_element(value)
+            
+            st.session_state["canvas"].append(svg)
+            st.session_state["canvas_elements_metadata"].append({
+                "type": element_type,
+                "value": value
+            })
+            st.success(f"✅ {element_type} added to canvas!")
         else:
-            svg = sticker_element(value)
+            st.error("❌ Please enter a value")
 
-        st.session_state["canvas"].append(svg)
+    st.markdown("---")
+
+    # --- Canvas Display & Export Section ---
+    if st.session_state["canvas"]:
+        st.subheader("Canvas Preview")
+        
+        # Generate composite canvas
+        canvas_svg = create_composite_canvas(
+            st.session_state["canvas"],
+            bg_color=current_theme_opts.get("bg_color", "#0d1117"),
+            padding=20
+        )
+        
+        # Display canvas
+        col_display, col_actions = st.columns([2, 1])
+        
+        with col_display:
+            b64 = base64.b64encode(canvas_svg.encode('utf-8')).decode("utf-8")
+            st.markdown(
+                f'<img src="data:image/svg+xml;base64,{b64}" style="max-width: 100%; box-shadow: 0 4px 6px rgba(0,0,0,0.3); border-radius: 10px;"/>',
+                unsafe_allow_html=True
+            )
+        
+        with col_actions:
+            st.markdown("**Canvas Actions**")
+            
+            # SVG Download
+            st.download_button(
+                label="⬇️ Download SVG",
+                data=canvas_svg.encode("utf-8"),
+                file_name=f"canvas_{username}.svg",
+                mime="image/svg+xml",
+                use_container_width=True
+            )
+            
+            # PNG & JPEG Download
+            svg_b64 = base64.b64encode(canvas_svg.encode("utf-8")).decode("utf-8")
+            filename_prefix_safe = json.dumps(f"canvas_{username}")
+            
+            st.components.v1.html(f"""
+            <div style="display:flex; flex-direction:column; gap:6px; margin-top:4px;">
+                <button onclick="downloadCanvasAs('png')" style="
+                    width:100%; padding:8px; font-size:12px; cursor:pointer;
+                    background:#1a1a2e; color:white; border:1px solid #444;
+                    border-radius:6px; font-weight: bold;">
+                    ⬇️ PNG
+                </button>
+                <button onclick="downloadCanvasAs('jpeg')" style="
+                    width:100%; padding:8px; font-size:12px; cursor:pointer;
+                    background:#1a1a2e; color:white; border:1px solid #444;
+                    border-radius:6px; font-weight: bold;">
+                    ⬇️ JPEG
+                </button>
+            </div>
+
+            <script>
+            function downloadCanvasAs(format) {{
+                const svgText = atob('{svg_b64}');
+                const parser = new DOMParser();
+                const svgDoc = parser.parseFromString(svgText, 'image/svg+xml');
+                const svgEl = svgDoc.documentElement;
+
+                const vb = svgEl.getAttribute('viewBox');
+                let w = 600, h = 400;
+                if (vb) {{
+                    const parts = vb.split(/[\\s,]+/);
+                    w = parseFloat(parts[2]) || 600;
+                    h = parseFloat(parts[3]) || 400;
+                }}
+
+                const blob = new Blob([svgText], {{type: 'image/svg+xml'}});
+                const url = URL.createObjectURL(blob);
+                const img = new Image();
+                img.onload = function() {{
+                    const SCALE = 2;
+                    const canvas = document.createElement('canvas');
+                    canvas.width = w * SCALE;
+                    canvas.height = h * SCALE;
+                    const ctx = canvas.getContext('2d');
+
+                    if (format === 'jpeg') {{
+                        ctx.fillStyle = '#ffffff';
+                        ctx.fillRect(0, 0, canvas.width, canvas.height);
+                    }}
+
+                    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+                    canvas.toBlob(function(blob) {{
+                        const link = document.createElement('a');
+                        link.download = {filename_prefix_safe} + (format === 'jpeg' ? '.jpeg' : '.png');
+                        link.href = URL.createObjectURL(blob);
+                        link.click();
+                        URL.revokeObjectURL(url);
+                    }}, 'image/' + format, 1.0);
+                }};
+                img.src = url;
+            }}
+            </script>
+            """, height=120)
+        
+        st.markdown("---")
+        st.subheader("Embed Code")
+        
+        # Generate embed URLs/code
+        embed_col1, embed_col2 = st.columns(2)
+        
+        with embed_col1:
+            st.markdown("**Markdown Code**")
+            embed_code = f"![Canvas - {username}](https://your-image-hosting.com/canvas_{username}.svg)"
+            st.text_area("Copy this code:", value=embed_code, height=60, label_visibility="collapsed", key="canvas_markdown_code")
+        
+        with embed_col2:
+            st.markdown("**HTML Code**")
+            html_code = f'<img src="https://your-image-hosting.com/canvas_{username}.svg" alt="Canvas - {username}"/>'
+            st.text_area("Copy this code:", value=html_code, height=60, label_visibility="collapsed", key="canvas_html_code")
+        
+        st.info("💡 **Note:** Download your canvas SVG above and host it on GitHub, Imgur, or any image hosting service, then use the embed code above.")
+        
+        st.markdown("---")
+        st.subheader("Canvas Contents")
+        
+        # Show list of elements
+        for idx, metadata in enumerate(st.session_state["canvas_elements_metadata"]):
+            col_item, col_remove = st.columns([4, 1])
+            with col_item:
+                st.caption(f"**{metadata['type']}** • {metadata['value']}")
+            with col_remove:
+                if st.button("🗑️", key=f"remove_{idx}", help="Remove this element"):
+                    st.session_state["canvas"].pop(idx)
+                    st.session_state["canvas_elements_metadata"].pop(idx)
+                    st.rerun()
+        
+        # Clear canvas button
+        if st.button("🧹 Clear All Canvas", use_container_width=True):
+            st.session_state["canvas"] = []
+            st.session_state["canvas_elements_metadata"] = []
+            st.rerun()
+    else:
+        st.info("👆 Add elements to your canvas to get started. You can mix emojis, GIFs, and stickers!")
 
 # TAB 11: Trophy Card
 with tab11:

--- a/generators/visual_elements.py
+++ b/generators/visual_elements.py
@@ -34,3 +34,82 @@ def sticker_element(image_url: str, size: int = 100) -> str:
         <image href="{image_url}" width="{size}" height="{size}" />
     </svg>
     """
+
+
+def create_composite_canvas(svg_elements: list, bg_color: str = "#0d1117", padding: int = 20) -> str:
+    """
+    Combine multiple SVG elements into a single composite canvas.
+    
+    Args:
+        svg_elements: List of SVG string elements
+        bg_color: Background color hex code
+        padding: Padding around elements
+    
+    Returns:
+        A single composite SVG string containing all elements arranged in a grid
+    """
+    if not svg_elements:
+        # Return empty canvas
+        return f"""
+        <svg xmlns="http://www.w3.org/2000/svg" width="600" height="400" viewBox="0 0 600 400">
+            <rect width="600" height="400" fill="{bg_color}"/>
+            <text x="300" y="200" text-anchor="middle" dominant-baseline="middle" 
+                  fill="#888" font-size="16px" font-family="Arial">
+                Your canvas is empty. Add elements to get started!
+            </text>
+        </svg>
+        """
+    
+    # Calculate grid layout
+    import math
+    cols = math.ceil(math.sqrt(len(svg_elements)))
+    rows = math.ceil(len(svg_elements) / cols)
+    
+    # Element dimensions
+    element_width = 140
+    element_height = 140
+    
+    # Canvas dimensions
+    canvas_width = cols * (element_width + padding) + padding
+    canvas_height = rows * (element_height + padding) + padding
+    
+    # Extract SVG content from each element (between <svg> tags)
+    svg_content_list = []
+    for idx, svg_str in enumerate(svg_elements):
+        # Parse the SVG to extract its contents
+        # Find content between opening and closing svg tags
+        start = svg_str.find('>') + 1
+        end = svg_str.rfind('</svg>')
+        if start > 0 and end > start:
+            content = svg_str[start:end]
+            svg_content_list.append((idx, content))
+    
+    # Build composite SVG with grid layout
+    composite = f"""
+    <svg xmlns="http://www.w3.org/2000/svg" width="{canvas_width}" height="{canvas_height}" viewBox="0 0 {canvas_width} {canvas_height}">
+        <rect width="{canvas_width}" height="{canvas_height}" fill="{bg_color}"/>
+        <style>
+            .canvas-border {{ stroke: #30363d; stroke-width: 1; fill: none; }}
+        </style>
+    """
+    
+    # Place elements in grid
+    for idx, content in svg_content_list:
+        col = idx % cols
+        row = idx // cols
+        x = padding + col * (element_width + padding)
+        y = padding + row * (element_height + padding)
+        
+        composite += f"""
+        <g transform="translate({x}, {y})">
+            <rect x="0" y="0" width="{element_width}" height="{element_height}" 
+                  class="canvas-border" rx="8"/>
+            <g transform="translate({element_width/2}, {element_height/2}) scale(1)">
+                {content}
+            </g>
+        </g>
+        """
+    
+    composite += "</svg>"
+    
+    return composite

--- a/test_theme_state.py
+++ b/test_theme_state.py
@@ -1,0 +1,43 @@
+import unittest
+
+from utils.theme_state import reset_theme_filter_state, theme_filter_widget_keys
+
+
+class ThemeStateTests(unittest.TestCase):
+    def test_theme_filter_widget_keys_are_namespaced(self):
+        keys = theme_filter_widget_keys("Space")
+
+        self.assertEqual(
+            keys,
+            {
+                "bg_color": "customize_bg_Space",
+                "title_color": "customize_title_Space",
+                "text_color": "customize_text_Space",
+                "border_color": "customize_border_Space",
+            },
+        )
+
+    def test_reset_theme_filter_state_restores_defaults(self):
+        session_state = {
+            "customize_bg_Space": "#111111",
+            "customize_title_Space": "#222222",
+            "customize_text_Space": "#333333",
+            "customize_border_Space": "#444444",
+        }
+        theme_defaults = {
+            "bg_color": "#0b0c1f",
+            "title_color": "#a371f7",
+            "text_color": "#d0dfff",
+            "border_color": "#6e5cdb",
+        }
+
+        reset_theme_filter_state(session_state, "Space", theme_defaults)
+
+        self.assertEqual(session_state["customize_bg_Space"], "#0b0c1f")
+        self.assertEqual(session_state["customize_title_Space"], "#a371f7")
+        self.assertEqual(session_state["customize_text_Space"], "#d0dfff")
+        self.assertEqual(session_state["customize_border_Space"], "#6e5cdb")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/theme_state.py
+++ b/utils/theme_state.py
@@ -1,0 +1,28 @@
+"""Helpers for Streamlit theme customization state."""
+
+from __future__ import annotations
+
+from typing import Any, MutableMapping
+
+
+THEME_FILTER_KEYS = ("bg_color", "title_color", "text_color", "border_color")
+
+
+def theme_filter_widget_keys(theme_name: str) -> dict[str, str]:
+    """Return the Streamlit widget keys for the theme color controls."""
+    return {
+        "bg_color": f"customize_bg_{theme_name}",
+        "title_color": f"customize_title_{theme_name}",
+        "text_color": f"customize_text_{theme_name}",
+        "border_color": f"customize_border_{theme_name}",
+    }
+
+
+def reset_theme_filter_state(
+    session_state: MutableMapping[str, Any],
+    theme_name: str,
+    theme_defaults: MutableMapping[str, Any],
+) -> None:
+    """Reset theme color widgets to the defaults for the selected theme."""
+    for color_key, widget_key in theme_filter_widget_keys(theme_name).items():
+        session_state[widget_key] = theme_defaults.get(color_key, "#000000")


### PR DESCRIPTION
I fixed the reset path in app.py and app.py so the theme controls now reset through a Streamlit callback instead of mutating widget-backed session state during render. That avoids the `StreamlitAPIException` you were seeing when clicking Reset Theme Filters. The reusable reset logic lives in theme_state.py, and I added a small regression test in test_theme_state.py.

Validation passed with `python -m unittest test_theme_state.py` and `python -m unittest test_theme_loader.py`.

closes #281