### PR TITLE
✨ Add Star Wars: The Force theme

### DIFF
--- a/generators/contrib_card.py
+++ b/generators/contrib_card.py
@@ -208,6 +208,7 @@ def _palette_from_theme(theme_name, theme):
         "Cyberpunk": ["#0a0e27", "#004a8c", "#0074c8", "#8e2ae6", "#d957b4"],
         "Ocean": ["#001122", "#003b55", "#00658a", "#0090c7", "#4dbfa8"],
         "Retro": ["#f5f0e1", "#d8c9ad", "#ba9f76", "#947658", "#6c563f"],
+        "Star Wars: The Force": ["#1F2833", "#4BD5EE", "#2FF924", "#8A2BE2", "#FF0000"],
     }
 
     if theme_name in palette_map:

--- a/themes/styles.py
+++ b/themes/styles.py
@@ -107,10 +107,21 @@ THEMES = {
         "text_color": "#ffffff",
         "icon_color": "#ff00ff",
         "font_family": "'Courier New', monospace",
-        "title_font_size": 18,
+        "title_font_size": 18, 
         "text_font_size": 14,
         "tags": ["dark", "neon", "colorful", "fun", "bold"]
-    }
+    },
+    "Star Wars: The Force": {
+    "bg_color": "#0B0C10",        # Deep space black
+    "border_color": "#FFE81F",     # Star Wars yellow for borders
+    "title_color": "#4BD5EE",      # Jedi Blue for titles
+    "text_color": "#FFFFFF",       # White text for contrast
+    "icon_color": "#FF0000",       # Sith Red for icons
+    "font_family": "'Orbitron', 'Courier New', monospace",
+    "title_font_size": 20,
+    "text_font_size": 14,
+    "tags": ["dark", "space", "sci-fi", "star wars", "colorful", "popular"]
+    },
 }
 import json
 import os


### PR DESCRIPTION
## ✨ Add Star Wars: The Force Theme

### 📋 Summary
This PR adds a new **Star Wars: The Force** theme to GitCanvas, bringing iconic Light Side and Dark Side colors to GitHub contribution visualizations.

### 🎨 Color Palette Implementation

| Contribution Level | Color Name | Hex Code | Force Aspect |
|-------------------|------------|----------|--------------|
| Background | Deep Space Black | `#0B0C10` | The Void |
| Level 0 (None) | Holographic Grey/Blue | `#1F2833` | Holocron Glow |
| Level 1 (Low) | Jedi Blue | `#4BD5EE` | Lightsaber (Blue) |
| Level 2 (Medium) | Yoda Green | `#2FF924` | Dagobah Swamp |
| Level 3 (High) | Mace Windu Purple | `#8A2BE2` | Vaapad Style |
| Level 4 (Max) | Sith Red | `#FF0000` | Dark Side Power |

### 📁 Files Modified

- [x] `themes/styles.py` - Added Star Wars theme configuration
- [x] `generators/contrib_card.py` - Added color palette mapping for contribution levels

### ✅ Testing Checklist

- [x] Theme appears in Theme Gallery dropdown
- [ ] Theme card displays correctly in gallery
- [ ] Contribution levels show correct Star Wars colors
- [x] Background renders as deep space black
- [x] Title text shows Jedi Blue color
- [x] Works with mock data
- [x] No breaking changes to existing themes
- [x] Code follows existing theme patterns

### 🔗 Related Issue

Closes #305 - Feature request for Star Wars theme

### 🚀 Additional Notes

- Theme tags: `["dark", "space", "sci-fi", "star wars", "colorful", "popular"]`
- Font family uses Orbitron for sci-fi feel
- Maintains consistency with existing theme structur
